### PR TITLE
Patched out Stord Warehouse Location data splay for primarily SellGoo…

### DIFF
--- a/mozartdata/transforms/fact/fulfillment_item_detail.sql
+++ b/mozartdata/transforms/fact/fulfillment_item_detail.sql
@@ -77,7 +77,7 @@ SELECT DISTINCT --adding just in case because NS joins can be funky and I don't 
 				TO_TIMESTAMP_NTZ(COALESCE(nsfulfill.CUSTBODYRFS_SHIPPED_AT, createddate))            AS shipped_at, --SADLY WE HAVE TO USE CREATEDDATE AS THE SHIPPING DATE AND JUST HOPE THAT IT WAS CREATED/SHIPPED THE SAME DAY BECAUSE NS DOESN'T STORE SHIPPEDDATE ANYWHERE
 -- 				NULL                          AS                                         shipmentcost,
 				NULL                                                                                 AS is_cancelled,
-				staged.location,
+				TO_CHAR(staged.location),
 				nsfulfill.ADDRESSEE,
 				nsfulfill.state,
 				nsfulfill.country,


### PR DESCRIPTION
Basically through a quick bit of deep exploration into Stord backorders with Alex I realized when he asked for the warehouse location of split shipments, our fulfillment level table was not pulling in the SHIPMENT's location, instead going to the sales order and pulling its variety of locations and then doubling them per order. So this will fix that data sply