### PR TITLE
Daily Inventory version 1

### DIFF
--- a/mozartdata/transforms/fact/inventory_reference_daily.sql
+++ b/mozartdata/transforms/fact/inventory_reference_daily.sql
@@ -4,7 +4,7 @@ with
                                 sku
                               , display_name
                               , snapshot_date
-                              , lower(location_name) || ' - shopify atp' as channel
+                              , lower(location_name) || ' - shopify inv' as channel
                               , quantity
                             from
                                 fact.inventory_location
@@ -35,7 +35,7 @@ netsuite_locations as (
     sku
     , display_name
     , snapshot_date
-    , lower(location_name) || ' - netsuite inventory' as location
+    , lower(location_name) || ' - netsuite inv' as location
     , quantity
   from
     fact.inventory_location
@@ -44,6 +44,11 @@ netsuite_locations as (
     and display_name is not null
     and lower(display_name) not like '%pre-pack%'
     and lower(display_name) not like '%pre pack%'
+    and lower(location_name) != 'hq dc - goodrglobal - do not use'
+    and lower(location_name) != 'hq damaged'
+    and lower(location_name) != 'hq dc - rei - do not use'
+    and lower(location_name) != 'pyramid'
+
 ),
 
 netsuite_locations_pivot as (
@@ -66,7 +71,7 @@ stord_locations as (
     sku
     , display_name
     , snapshot_date
-    , lower(location_name) || ' - stord inventory' as location
+    , lower(location_name) || ' - stord inv' as location
     , quantity
   from
     fact.inventory_location
@@ -97,7 +102,7 @@ stord_reservations as (
     sku
     , name
     , snapshot_date
-    , lower(channel) || ' - stord reservations' as channel
+    , lower(channel) || ' - stord resv' as channel
     , reservation_quantity
   from
     fact.stord_inventory_reservations

--- a/mozartdata/transforms/fact/inventory_reference_monthly_change.sql
+++ b/mozartdata/transforms/fact/inventory_reference_monthly_change.sql
@@ -15,185 +15,157 @@ select
   , display_name
   , snapshot_date as month_start
   , ifnull(
-        "'goodr.ca - shopify inv'", 0
-    ) - ifnull(
-        lag(
-            "'goodr.ca - shopify inv'"
-        ) over (
+        goodr_ca_shopify_inv - lag(
+            goodr_ca_shopify_inv
+                               ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as goodr_ca_shopify_inv_mom_diff
+        , 0) as goodr_ca_shopify_inv_mom_diff
   , ifnull(
-        "'goodr.com - shopify inv'", 0
-    ) - ifnull(
-        lag(
-            "'goodr.com - shopify inv'"
+        goodr_com_shopify_inv - lag(
+            goodr_com_shopify_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as goodr_com_shopify_inv_mom_diff
+        , 0) as goodr_com_shopify_inv_mom_diff
   , ifnull(
-        "'goodrwill - shopify inv'", 0
-    ) - ifnull(
-        lag(
-            "'goodrwill - shopify inv'"
+        goodrwill_shopify_inv - lag(
+            goodrwill_shopify_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as goodrwill_shopify_inv_mom_diff
+        , 0) as goodrwill_shopify_inv_mom_diff
   , ifnull(
-        "'specialty - shopify inv'", 0
-    ) - ifnull(
-        lag(
-            "'specialty - shopify inv'"
-        ) over (
+        specialty_shopify_inv - lag(
+            specialty_shopify_inv
+                                ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as specialty_shopify_inv_mom_diff
+        , 0) as specialty_shopify_inv_mom_diff
   , ifnull(
-        "'specialty can - shopify inv'", 0
-    ) - ifnull(
-        lag(
-            "'specialty can - shopify inv'"
+        specialty_can_shopify_inv - lag(
+            specialty_can_shopify_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as specialty_can_shopify_inv_mom_diff
+        , 0) as specialty_can_shopify_inv_mom_diff
   , ifnull(
-        "'donation - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'donation - netsuite inv'"
+        donation_netsuite_inv - lag(
+            donation_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as donation_netsuite_inv_mom_diff
+        , 0) as donation_netsuite_inv_mom_diff
   , ifnull(
-        "'drop ship - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'drop ship - netsuite inv'"
+        drop_ship_netsuite_inv - lag(
+            drop_ship_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as drop_ship_netsuite_inv_mom_diff
+        , 0) as drop_ship_netsuite_inv_mom_diff
   , ifnull(
-        "'hq dc - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'hq dc - netsuite inv'"
+        hq_dc_netsuite_inv - lag(
+            hq_dc_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as hq_dc_netsuite_inv_mom_diff
+        , 0) as hq_dc_netsuite_inv_mom_diff
   , ifnull(
-        "'lensabl den - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'lensabl den - netsuite inv'"
+        lensabl_den_netsuite_inv - lag(
+            lensabl_den_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as lensabl_den_netsuite_inv_mom_diff
+        , 0) as lensabl_den_netsuite_inv_mom_diff
   , ifnull(
-        "'qc pending - do not use - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'qc pending - do not use - netsuite inv'"
+        qc_pending_do_not_use_netsuite_inv - lag(
+            qc_pending_do_not_use_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as qc_pending_netsuite_inv_mom_diff
+        , 0) as qc_pending_netsuite_inv_mom_diff
   , ifnull(
-        "'retail - cabana damages - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'retail - cabana damages - netsuite inv'"
+        retail_cabana_damages_netsuite_inv - lag(
+            retail_cabana_damages_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as retail_cabana_damages_netsuite_inv_mom_diff
+        , 0) as retail_cabana_damages_netsuite_inv_mom_diff
   , ifnull(
-        "'stord atl - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'stord atl - netsuite inv'"
+        retail_goodrcabana_netsuite_inv - lag(
+            retail_goodrcabana_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as stord_atl_netsuite_inv_mom_diff
+        , 0) as retail_goodrcabana_netsuite_inv_mom_diff
   , ifnull(
-        "'stord hold - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'stord hold - netsuite inv'"
+        stord_atl_netsuite_inv - lag(
+            stord_atl_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as stord_hold_netsuite_inv_mom_diff
+        , 0) as stord_atl_netsuite_inv_mom_diff
   , ifnull(
-        "'stord las - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'stord las - netsuite inv'"
+        stord_hold_netsuite_inv - lag(
+            stord_hold_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as stord_las_netsuite_inv_mom_diff
+        , 0) as stord_hold_netsuite_inv_mom_diff
   , ifnull(
-        "'wh amazon - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'wh amazon - netsuite inv'"
+        stord_las_netsuite_inv - lag(
+            stord_las_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as wh_amazon_netsuite_inv_mom_diff
+        , 0) as stord_las_netsuite_inv_mom_diff
   , ifnull(
-        "'wh amazon canada - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'wh amazon canada - netsuite inv'"
+        wh_amazon_netsuite_inv - lag(
+            wh_amazon_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as wh_amazon_canada_netsuite_inv_mom_diff
+        , 0) as wh_amazon_netsuite_inv_mom_diff
   , ifnull(
-        "'atls001 - stord inv'", 0
-    ) - ifnull(
-        lag(
-            "'atls001 - stord inv'"
+        wh_amazon_canada_netsuite_inv - lag(
+            wh_amazon_canada_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as atls001_stord_inv_mom_diff
+        , 0) as wh_amazon_canada_netsuite_inv_mom_diff
   , ifnull(
-        "'lass002 - stord inv'", 0
-    ) - ifnull(
-        lag(
-            "'lass002 - stord inv'"
+        atls001_stord_inv - lag(
+            atls001_stord_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
-        , 0)      as lass002_stord_inv_mom_diff
+        , 0) as atls001_stord_inv_mom_diff
+  , ifnull(
+        lass002_stord_inv - lag(
+            lass002_stord_inv
+                            ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0) as lass002_stord_inv_mom_diff
 from
     month_starts_cte
 order by

--- a/mozartdata/transforms/fact/inventory_reference_monthly_change.sql
+++ b/mozartdata/transforms/fact/inventory_reference_monthly_change.sql
@@ -1,0 +1,200 @@
+with
+    month_starts_cte as (
+                            select
+                                *
+                            from
+                                fact.inventory_reference_daily
+                            where
+                                date_trunc(month, snapshot_date::date) = snapshot_date
+                            order by
+                                snapshot_date asc
+    )
+
+select
+    sku
+  , display_name
+  , snapshot_date as month_start
+  , ifnull(
+        "'goodr.ca - shopify inv'", 0
+    ) - ifnull(
+        lag(
+            "'goodr.ca - shopify inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as goodr_ca_shopify_inv_mom_diff
+  , ifnull(
+        "'goodr.com - shopify inv'", 0
+    ) - ifnull(
+        lag(
+            "'goodr.com - shopify inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as goodr_com_shopify_inv_mom_diff
+  , ifnull(
+        "'goodrwill - shopify inv'", 0
+    ) - ifnull(
+        lag(
+            "'goodrwill - shopify inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as goodrwill_shopify_inv_mom_diff
+  , ifnull(
+        "'specialty - shopify inv'", 0
+    ) - ifnull(
+        lag(
+            "'specialty - shopify inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as specialty_shopify_inv_mom_diff
+  , ifnull(
+        "'specialty can - shopify inv'", 0
+    ) - ifnull(
+        lag(
+            "'specialty can - shopify inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as specialty_can_shopify_inv_mom_diff
+  , ifnull(
+        "'donation - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'donation - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as donation_netsuite_inv_mom_diff
+  , ifnull(
+        "'drop ship - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'drop ship - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as drop_ship_netsuite_inv_mom_diff
+  , ifnull(
+        "'hq dc - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'hq dc - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as hq_dc_netsuite_inv_mom_diff
+  , ifnull(
+        "'lensabl den - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'lensabl den - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as lensabl_den_netsuite_inv_mom_diff
+  , ifnull(
+        "'qc pending - do not use - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'qc pending - do not use - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as qc_pending_netsuite_inv_mom_diff
+  , ifnull(
+        "'retail - cabana damages - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'retail - cabana damages - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as retail_cabana_damages_netsuite_inv_mom_diff
+  , ifnull(
+        "'stord atl - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'stord atl - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as stord_atl_netsuite_inv_mom_diff
+  , ifnull(
+        "'stord hold - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'stord hold - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as stord_hold_netsuite_inv_mom_diff
+  , ifnull(
+        "'stord las - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'stord las - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as stord_las_netsuite_inv_mom_diff
+  , ifnull(
+        "'wh amazon - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'wh amazon - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as wh_amazon_netsuite_inv_mom_diff
+  , ifnull(
+        "'wh amazon canada - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'wh amazon canada - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as wh_amazon_canada_netsuite_inv_mom_diff
+  , ifnull(
+        "'atls001 - stord inv'", 0
+    ) - ifnull(
+        lag(
+            "'atls001 - stord inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as atls001_stord_inv_mom_diff
+  , ifnull(
+        "'lass002 - stord inv'", 0
+    ) - ifnull(
+        lag(
+            "'lass002 - stord inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as lass002_stord_inv_mom_diff
+from
+    month_starts_cte
+order by
+    sku

--- a/mozartdata/transforms/fact/inventory_reference_weekly_change.sql
+++ b/mozartdata/transforms/fact/inventory_reference_weekly_change.sql
@@ -1,5 +1,5 @@
 with
-    month_starts_cte as (
+    week_starts_cte as (
                             select
                                 *
                             from
@@ -167,6 +167,6 @@ select
                 )
         , 0)      as lass002_stord_inv_wow_diff
 from
-    month_starts_cte
+    week_starts_cte
 order by
     sku

--- a/mozartdata/transforms/fact/inventory_reference_weekly_change.sql
+++ b/mozartdata/transforms/fact/inventory_reference_weekly_change.sql
@@ -1,0 +1,200 @@
+with
+    month_starts_cte as (
+                            select
+                                *
+                            from
+                                fact.inventory_reference_daily
+                            where
+                                date_trunc('WEEK', snapshot_date) = snapshot_date
+                            order by
+                                snapshot_date asc
+    )
+
+select
+    sku
+  , display_name
+  , snapshot_date as week_start
+  , ifnull(
+        "'goodr.ca - shopify inv'", 0
+    ) - ifnull(
+        lag(
+            "'goodr.ca - shopify inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as goodr_ca_shopify_inv_wow_diff
+  , ifnull(
+        "'goodr.com - shopify inv'", 0
+    ) - ifnull(
+        lag(
+            "'goodr.com - shopify inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as goodr_com_shopify_inv_wow_diff
+  , ifnull(
+        "'goodrwill - shopify inv'", 0
+    ) - ifnull(
+        lag(
+            "'goodrwill - shopify inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as goodrwill_shopify_inv_wow_diff
+  , ifnull(
+        "'specialty - shopify inv'", 0
+    ) - ifnull(
+        lag(
+            "'specialty - shopify inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as specialty_shopify_inv_wow_diff
+  , ifnull(
+        "'specialty can - shopify inv'", 0
+    ) - ifnull(
+        lag(
+            "'specialty can - shopify inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as specialty_can_shopify_inv_wow_diff
+  , ifnull(
+        "'donation - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'donation - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as donation_netsuite_inv_wow_diff
+  , ifnull(
+        "'drop ship - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'drop ship - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as drop_ship_netsuite_inv_wow_diff
+  , ifnull(
+        "'hq dc - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'hq dc - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as hq_dc_netsuite_inv_wow_diff
+  , ifnull(
+        "'lensabl den - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'lensabl den - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as lensabl_den_netsuite_inv_wow_diff
+  , ifnull(
+        "'qc pending - do not use - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'qc pending - do not use - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as qc_pending_netsuite_inv_wow_diff
+  , ifnull(
+        "'retail - cabana damages - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'retail - cabana damages - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as retail_cabana_damages_netsuite_inv_wow_diff
+  , ifnull(
+        "'stord atl - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'stord atl - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as stord_atl_netsuite_inv_wow_diff
+  , ifnull(
+        "'stord hold - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'stord hold - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as stord_hold_netsuite_inv_wow_diff
+  , ifnull(
+        "'stord las - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'stord las - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as stord_las_netsuite_inv_wow_diff
+  , ifnull(
+        "'wh amazon - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'wh amazon - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as wh_amazon_netsuite_inv_wow_diff
+  , ifnull(
+        "'wh amazon canada - netsuite inv'", 0
+    ) - ifnull(
+        lag(
+            "'wh amazon canada - netsuite inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as wh_amazon_canada_netsuite_inv_wow_diff
+  , ifnull(
+        "'atls001 - stord inv'", 0
+    ) - ifnull(
+        lag(
+            "'atls001 - stord inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as atls001_stord_inv_wow_diff
+  , ifnull(
+        "'lass002 - stord inv'", 0
+    ) - ifnull(
+        lag(
+            "'lass002 - stord inv'"
+        ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as lass002_stord_inv_wow_diff
+from
+    month_starts_cte
+order by
+    sku

--- a/mozartdata/transforms/fact/inventory_reference_weekly_change.sql
+++ b/mozartdata/transforms/fact/inventory_reference_weekly_change.sql
@@ -5,7 +5,7 @@ with
                             from
                                 fact.inventory_reference_daily
                             where
-                                date_trunc('WEEK', snapshot_date) = snapshot_date
+                                date_trunc(week, snapshot_date::date) = snapshot_date
                             order by
                                 snapshot_date asc
     )
@@ -13,182 +13,154 @@ with
 select
     sku
   , display_name
-  , snapshot_date as week_start
+  , snapshot_date as month_start
   , ifnull(
-        "'goodr.ca - shopify inv'", 0
-    ) - ifnull(
-        lag(
-            "'goodr.ca - shopify inv'"
-        ) over (
+        goodr_ca_shopify_inv - lag(
+            goodr_ca_shopify_inv
+                               ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as goodr_ca_shopify_inv_wow_diff
   , ifnull(
-        "'goodr.com - shopify inv'", 0
-    ) - ifnull(
-        lag(
-            "'goodr.com - shopify inv'"
+        goodr_com_shopify_inv - lag(
+            goodr_com_shopify_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as goodr_com_shopify_inv_wow_diff
   , ifnull(
-        "'goodrwill - shopify inv'", 0
-    ) - ifnull(
-        lag(
-            "'goodrwill - shopify inv'"
+        goodrwill_shopify_inv - lag(
+            goodrwill_shopify_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as goodrwill_shopify_inv_wow_diff
   , ifnull(
-        "'specialty - shopify inv'", 0
-    ) - ifnull(
-        lag(
-            "'specialty - shopify inv'"
-        ) over (
+        specialty_shopify_inv - lag(
+            specialty_shopify_inv
+                                ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as specialty_shopify_inv_wow_diff
   , ifnull(
-        "'specialty can - shopify inv'", 0
-    ) - ifnull(
-        lag(
-            "'specialty can - shopify inv'"
+        specialty_can_shopify_inv - lag(
+            specialty_can_shopify_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as specialty_can_shopify_inv_wow_diff
   , ifnull(
-        "'donation - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'donation - netsuite inv'"
+        donation_netsuite_inv - lag(
+            donation_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as donation_netsuite_inv_wow_diff
   , ifnull(
-        "'drop ship - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'drop ship - netsuite inv'"
+        drop_ship_netsuite_inv - lag(
+            drop_ship_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as drop_ship_netsuite_inv_wow_diff
   , ifnull(
-        "'hq dc - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'hq dc - netsuite inv'"
+        hq_dc_netsuite_inv - lag(
+            hq_dc_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as hq_dc_netsuite_inv_wow_diff
   , ifnull(
-        "'lensabl den - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'lensabl den - netsuite inv'"
+        lensabl_den_netsuite_inv - lag(
+            lensabl_den_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as lensabl_den_netsuite_inv_wow_diff
   , ifnull(
-        "'qc pending - do not use - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'qc pending - do not use - netsuite inv'"
+        qc_pending_do_not_use_netsuite_inv - lag(
+            qc_pending_do_not_use_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as qc_pending_netsuite_inv_wow_diff
   , ifnull(
-        "'retail - cabana damages - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'retail - cabana damages - netsuite inv'"
+        retail_cabana_damages_netsuite_inv - lag(
+            retail_cabana_damages_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as retail_cabana_damages_netsuite_inv_wow_diff
   , ifnull(
-        "'stord atl - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'stord atl - netsuite inv'"
+        retail_goodrcabana_netsuite_inv - lag(
+            retail_goodrcabana_netsuite_inv
+                                          ) over (
+                partition by sku
+                order by snapshot_date
+                )
+        , 0)      as retail_goodrcabana_netsuite_inv_wow_diff
+  , ifnull(
+        stord_atl_netsuite_inv - lag(
+            stord_atl_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as stord_atl_netsuite_inv_wow_diff
   , ifnull(
-        "'stord hold - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'stord hold - netsuite inv'"
+        stord_hold_netsuite_inv - lag(
+            stord_hold_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as stord_hold_netsuite_inv_wow_diff
   , ifnull(
-        "'stord las - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'stord las - netsuite inv'"
+        stord_las_netsuite_inv - lag(
+            stord_las_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as stord_las_netsuite_inv_wow_diff
   , ifnull(
-        "'wh amazon - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'wh amazon - netsuite inv'"
+        wh_amazon_netsuite_inv - lag(
+            wh_amazon_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as wh_amazon_netsuite_inv_wow_diff
   , ifnull(
-        "'wh amazon canada - netsuite inv'", 0
-    ) - ifnull(
-        lag(
-            "'wh amazon canada - netsuite inv'"
+        wh_amazon_canada_netsuite_inv - lag(
+            wh_amazon_canada_netsuite_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as wh_amazon_canada_netsuite_inv_wow_diff
   , ifnull(
-        "'atls001 - stord inv'", 0
-    ) - ifnull(
-        lag(
-            "'atls001 - stord inv'"
+        atls001_stord_inv - lag(
+            atls001_stord_inv
         ) over (
                 partition by sku
                 order by snapshot_date
                 )
         , 0)      as atls001_stord_inv_wow_diff
   , ifnull(
-        "'lass002 - stord inv'", 0
-    ) - ifnull(
-        lag(
-            "'lass002 - stord inv'"
+        lass002_stord_inv - lag(
+            lass002_stord_inv
         ) over (
                 partition by sku
                 order by snapshot_date

--- a/mozartdata/transforms/goodr_reporting/inventory_reference_daily.sql
+++ b/mozartdata/transforms/goodr_reporting/inventory_reference_daily.sql
@@ -1,0 +1,148 @@
+with
+    shopify_channels as (
+                            select
+                                sku
+                              , display_name
+                              , snapshot_date
+                              , lower(location_name) || ' - shopify atp' as channel
+                              , quantity
+                            from
+                                fact.inventory_location
+                            where
+                                  lower(source) = 'shopify'
+                              and display_name is not null
+                              and lower(display_name) not like '%pre-pack%'
+                              and lower(display_name) not like '%pre pack%'
+                        )
+  , shopify_channels_pivot as (
+                            select
+                                *
+                            from
+                                shopify_channels
+    pivot
+( sum(quantity) for channel in (
+    select distinct
+    channel
+    from
+    shopify_channels
+    )
+)
+as p
+),
+
+netsuite_locations as (
+  select
+    sku
+    , display_name
+    , snapshot_date
+    , lower(location_name) || ' - netsuite inventory' as location
+    , quantity
+  from
+    fact.inventory_location
+  where
+    lower(source) = 'netsuite'
+    and display_name is not null
+    and lower(display_name) not like '%pre-pack%'
+    and lower(display_name) not like '%pre pack%'
+),
+
+netsuite_locations_pivot as (
+  select
+    *
+  from
+    netsuite_locations
+  pivot(
+    sum(quantity) for location in (
+      select distinct
+        location
+      from
+        netsuite_locations
+    )
+  ) as p
+),
+
+stord_locations as (
+  select
+    sku
+    , display_name
+    , snapshot_date
+    , lower(location_name) || ' - stord inventory' as location
+    , quantity
+  from
+    fact.inventory_location
+  where
+    lower(source) = 'stord'
+    and display_name is not null
+    and lower(display_name) not like '%pre-pack%'
+    and lower(display_name) not like '%pre pack%'
+),
+
+stord_locations_pivot as (
+  select
+    *
+  from
+    stord_locations
+  pivot(
+    sum(quantity) for location in (
+      select distinct
+        location
+      from
+        stord_locations
+    )
+  ) as p
+),
+
+stord_reservations as (
+  select
+    sku
+    , name
+    , snapshot_date
+    , lower(channel) || ' - stord reservations' as channel
+    , reservation_quantity
+  from
+    fact.stord_inventory_reservations
+  where
+    lower(channel) not in (
+      'transfer orders'
+    )
+),
+
+stord_reservations_pivot as (
+  select
+    *
+  from
+    stord_reservations
+  pivot(
+    sum(reservation_quantity) for channel in (
+      select distinct
+        channel
+      from
+        stord_reservations
+    )
+  ) as p
+)
+
+select distinct
+    shopify.*
+  , netsuite.* exclude (sku, display_name, snapshot_date)
+  , stord.* exclude (sku, display_name, snapshot_date)
+  , res.* exclude (sku, name, snapshot_date)
+from
+    shopify_channels_pivot       as shopify
+    left join
+        netsuite_locations_pivot as netsuite
+            on
+            shopify.sku = netsuite.sku
+                and shopify.snapshot_date = netsuite.snapshot_date
+    left join
+        stord_locations_pivot    as stord
+            on
+            shopify.sku = stord.sku
+                and shopify.snapshot_date = stord.snapshot_date
+    left join
+        stord_reservations_pivot as res
+            on
+            shopify.sku = res.sku
+                and shopify.snapshot_date = res.snapshot_date
+order by
+    shopify.snapshot_date desc


### PR DESCRIPTION
This is an extremely crude way to get daily inventory for multiple systems. It needs a lot of improvement including a dynamic query to remove the quotes in columns likely using a stored procedure, improvements to base level tables to have a column showing when stores are inactive, and a way to pull in key accounts, marketing, customer service and the cabana shopify channels to understand their inventory.

It needs much more work.