### PR TITLE
Canada store names to be consistent

### DIFF
--- a/mozartdata/transforms/dim/product.sql
+++ b/mozartdata/transforms/dim/product.sql
@@ -32,70 +32,70 @@ WITH
                    up.sku
                  , max(
                            iff(
-                                   shop_prod.shopify_store = 'd2c'
+                                   shop_prod.shopify_store = 'Goodr.com'
                                , shop_prod.product_id
                                , null
                            )
                    ) as product_id_d2c_shopify
                  , max(
                            iff(
-                                   shop_prod.shopify_store = 'b2b'
+                                   shop_prod.shopify_store = 'Specialty'
                                , shop_prod.product_id
                                , null
                            )
                    ) as product_id_b2b_shopify
                  , max(
                            iff(
-                                   shop_prod.shopify_store = 'goodrwill'
+                                   shop_prod.shopify_store = 'Goodrwill'
                                , shop_prod.product_id
                                , null
                            )
                    ) as product_id_goodrwill_shopify
                  , max(
                            iff(
-                                   shop_prod.shopify_store = 'd2c_can'
+                                   shop_prod.shopify_store = 'Goodr.ca'
                                , shop_prod.product_id
                                , null
                            )
                    ) as product_id_d2c_can_shopify
                  , max(
                            iff(
-                                   shop_prod.shopify_store = 'b2b_can'
+                                   shop_prod.shopify_store = 'Specialty CAN'
                                , shop_prod.product_id
                                , null
                            )
                    ) as product_id_b2b_can_shopify
                  , max(
                            iff(
-                                   shop_prod.shopify_store = 'd2c'
+                                   shop_prod.shopify_store = 'Goodr.com'
                                , shop_prod.inventory_item_id
                                , null
                            )
                    ) as inventory_item_id_d2c_shopify
                  , max(
                            iff(
-                                   shop_prod.shopify_store = 'b2b'
+                                   shop_prod.shopify_store = 'Specialty'
                                , shop_prod.inventory_item_id
                                , null
                            )
                    ) as inventory_item_id_b2b_shopify
                  , max(
                            iff(
-                                   shop_prod.shopify_store = 'goodrwill'
+                                   shop_prod.shopify_store = 'Goodrwill'
                                , shop_prod.inventory_item_id
                                , null
                            )
                    ) as inventory_item_id_goodrwill_shopify
                  , max(
                            iff(
-                                   shop_prod.shopify_store = 'd2c_can'
+                                   shop_prod.shopify_store = 'Goodr.ca'
                                , shop_prod.inventory_item_id
                                , null
                            )
                    ) as inventory_item_id_d2c_can_shopify
                  , max(
                            iff(
-                                   shop_prod.shopify_store = 'b2b'
+                                   shop_prod.shopify_store = 'Specialty'
                                , shop_prod.inventory_item_id
                                , null
                            )

--- a/mozartdata/transforms/fact/shopify_order_item.sql
+++ b/mozartdata/transforms/fact/shopify_order_item.sql
@@ -61,7 +61,7 @@ FROM
 SELECT
   b2b_shop.name order_id_edw,
   b2b_shop.id order_id_shopify,
-  'Specialty Canada' AS store,
+  'Specialty CAN' AS store,
   line.id AS order_line_id,
   product.product_id_edw,
   line.sku,
@@ -81,7 +81,7 @@ FROM
 SELECT
   b2b_shop.name order_id_edw,
   b2b_shop.id order_id_shopify,
-  'Canada D2C' AS store,
+  'Goodr.ca' AS store,
   line.id AS order_line_id,
   product.product_id_edw,
   line.sku,

--- a/mozartdata/transforms/fact/shopify_order_line.sql
+++ b/mozartdata/transforms/fact/shopify_order_line.sql
@@ -63,7 +63,7 @@ UNION ALL
 SELECT DISTINCT
   d2c_can_shop.name order_id_edw,
   d2c_can_shop.id order_id_shopify,
-  'Canada D2C' AS store,
+  'Goodr.ca' AS store,
   d2c_can_shop.email,
   d2c_can_shop.total_line_items_price as amount_booked,
   ship.price as shipping_sold,
@@ -94,7 +94,7 @@ UNION ALL
 SELECT DISTINCT
   b2b_can_shop.name order_id_edw,
   b2b_can_shop.id order_id_shopify,
-  'Specialty Canada' AS store,
+  'Specialty CAN' AS store,
   b2b_can_shop.email,
   b2b_can_shop.total_line_items_price as amount_booked,
   ship.price as shipping_sold,

--- a/mozartdata/transforms/goodr_reporting/missed_sales.sql
+++ b/mozartdata/transforms/goodr_reporting/missed_sales.sql
@@ -75,10 +75,7 @@ WITH
         daily_sales ds
         ON ds.sold_date between dateadd(days,-30,il.snapshot_date) and il.snapshot_date
           AND il.sku = ds.sku
-          AND il.store = CASE
-                           WHEN ds.store = 'Canada D2C' THEN 'Goodr.ca'
-                           WHEN ds.store = 'Specialty Canada' THEN 'Specialty CAN'
-                           ELSE ds.store END
+          AND il.store = ds.store
           AND ds.quantity_sold >0
       GROUP BY
         il.inventory_month

--- a/mozartdata/transforms/staging/shopify_products.sql
+++ b/mozartdata/transforms/staging/shopify_products.sql
@@ -24,7 +24,7 @@ SELECT
   , variant.weight
   , variant.weight_unit
   , variant.option_1
-  , 'd2c'         AS shopify_store
+  , 'Goodr.com'         AS shopify_store
 FROM
     shopify.PRODUCT_VARIANT variant
     LEFT OUTER JOIN
@@ -56,7 +56,7 @@ SELECT
   , variant.weight
   , variant.weight_unit
   , variant.option_1
-  , 'b2b'         AS shopify_store
+  , 'Specialty'         AS shopify_store
 FROM
     SPECIALTY_SHOPIFY.PRODUCT_VARIANT         variant
     LEFT OUTER JOIN SPECIALTY_SHOPIFY.PRODUCT prod
@@ -87,7 +87,7 @@ SELECT
   , variant.weight
   , variant.weight_unit
   , variant.option_1
-  , 'goodrwill'         AS shopify_store
+  , 'Goodrwill'         AS shopify_store
 FROM
     GOODRWILL_SHOPIFY.PRODUCT_VARIANT         variant
     LEFT OUTER JOIN GOODRWILL_SHOPIFY.PRODUCT prod
@@ -118,7 +118,7 @@ SELECT
   , variant.weight
   , variant.weight_unit
   , variant.option_1
-  , 'b2b_can'         AS shopify_store
+  , 'Specialty CAN'         AS shopify_store
 FROM
     SELLGOODR_CANADA_SHOPIFY.PRODUCT_VARIANT         variant
     LEFT OUTER JOIN SELLGOODR_CANADA_SHOPIFY.PRODUCT prod
@@ -149,7 +149,7 @@ SELECT
   , variant.weight
   , variant.weight_unit
   , variant.option_1
-  , 'd2c_can'         AS shopify_store
+  , 'Goodr.ca'         AS shopify_store
 FROM
     GOODR_CANADA_SHOPIFY.PRODUCT_VARIANT         variant
     LEFT OUTER JOIN GOODR_CANADA_SHOPIFY.PRODUCT prod


### PR DESCRIPTION
While working on Shopify Discounts, I discovered inconsistent naming of our Shopify stores within the dwh. For the most part we have been consistent, but this closes any inconsistencies we have.

old -> new
- d2c -> Goodr.com
- d2c_can -> Goodr.ca
- b2b -> Specialty
- b2b_can -> Specialty CAN
- goodrwill -> Goodrwill
- Canada D2C -> Goodr.ca
- Specialty Canada -> Specialty CAN
 