### PR TITLE
expanding logic to capture more fleet feet customers

### DIFF
--- a/mozartdata/transforms/staging/netsuite_customers.sql
+++ b/mozartdata/transforms/staging/netsuite_customers.sql
@@ -42,7 +42,7 @@ SELECT cust.id                                                                 A
      coalesce(parent_tier.id,tiers.id) as tier_id_ns,
      coalesce(parent_tier.name,tiers.name) as tier_ns,
      case when coalesce(parent_tier.name,tiers.name) = 'Named' then
-       case when lower(cust.companyname) like '%fleet feet%' then 'Fleet Feet' else cust.companyname
+       case when lower(cust.companyname) like '%fleet feet%' or lower(cust.email) like '%fleetfeet%' then 'Fleet Feet' else cust.companyname
        end else coalesce(parent_tier.name,tiers.name)  end as tier,
      cust.custentityam_doors as doors,
      cust.custentityam_buyer_name as buyer_name,


### PR DESCRIPTION
Issue: we were missing some Fleet Feet tier customers, because they were children and the company name did not include 'Fleet Feet'. 

Per alex/kaden we can rely on email containing fleet feet if the parent is FF. So we shouldn't just rely on company name

all of these will be updated. Note the 3 which aren't updated will be updated when we resync NS tomorrow. Alex added those 3 as children of FF.
![image](https://github.com/user-attachments/assets/5d28a2b0-017c-43c8-abcc-fb734196e530)

