### PR TITLE
fixed shipping added line refunds

### DIFF
--- a/mozartdata/transforms/fact/shopify_orders.sql
+++ b/mozartdata/transforms/fact/shopify_orders.sql
@@ -1,15 +1,25 @@
+with refunds as
+  (
+    select
+      r.order_id_shopify
+    ,  round(sum(r.amount_refund_line_total),2) as amount_refunded
+    from
+      fact.shopify_refund_order_item r
+    group by all
+  )
 SELECT DISTINCT
   o.order_id_edw,
   o.order_id_shopify,
   o.store,
   o.email,
   o.total_line_items_price as amount_booked,
-  ship.price as shipping_sold,
+  coalesce(ship.price,0) as shipping_sold,
   o.amount_tax_sold as amount_tax_sold,
   o.amount_sold as amount_sold,
-  round(o.amount_sold - o.amount_tax_sold - ship.price + o.amount_discount,2) as amount_product_sold,
+  round(o.amount_sold - o.amount_tax_sold - coalesce(ship.price,0) + o.amount_discount,2) as amount_product_sold,
   round(o.amount_sold - o.amount_tax_sold,2) as amount_revenue_sold,
   o.amount_discount*-1 as amount_discount,
+  coalesce(r.amount_refunded,0) as amount_refunded,
   o.created_at as order_created_timestamp,
   DATE(o.created_at) as order_created_date,
   CONVERT_TIMEZONE('America/Los_Angeles', o.created_at) AS order_created_timestamp_pst,
@@ -34,3 +44,4 @@ FROM
   staging.shopify_orders o
   LEFT OUTER JOIN staging.shopify_order_line line ON line.order_id_shopify = o.order_id_shopify and o.store = line.store
   LEFT OUTER JOIN staging.shopify_order_shipping_line ship ON ship.order_id_shopify = o.order_id_shopify and o.store = ship.store
+  LEFT OUTER JOIN refunds r on o.order_id_shopify = r.order_id_shopify


### PR DESCRIPTION
Fixes 2 issues. Shipping is null for cabana, so amount_product was showing up as null, because $ + null = null (LAME!)

adding amount_refunded which is just including line refunds for right now. we'll work in adjustments later