### PR TITLE
fix for amount_sales

### DIFF
--- a/mozartdata/transforms/fact/shopify_orders.sql
+++ b/mozartdata/transforms/fact/shopify_orders.sql
@@ -18,23 +18,37 @@ with gift_cards as
       fact.shopify_refund_order_item r
     group by all
   )
+, line_aggregates as
+  (
+    select
+      line.order_id_shopify,
+      line.store,
+      SUM(line.quantity_sold)  as quantity_sold,
+      SUM(line.quantity_booked) as quantity_booked,
+      sum(line.amount_yotpo_discount) as amount_yotpo_discount,
+      sum(line.amount_standard_discount) as amount_standard_discount,
+      sum(line.amount_total_discount) as amount_total_discount
+    from
+      fact.shopify_order_line line
+    group by all
+  )
 SELECT DISTINCT
   o.order_id_edw,
   o.order_id_shopify,
   o.store,
   o.email,
   o.customer_id as customer_id_shopify,
-  SUM(line.quantity_sold)  as quantity_sold,
-  SUM(line.quantity_booked) as quantity_booked,
+  line.quantity_sold,
+  line.quantity_booked,
   o.total_line_items_price as amount_booked,
   coalesce(ship.price,0) as shipping_sold,
   o.amount_tax_sold as amount_tax_sold,
   o.amount_sold as amount_sold,
   round(o.amount_sold - o.amount_tax_sold - coalesce(ship.price,0) + o.amount_discount,2) as amount_product_sold,
-  round(o.amount_sold - o.amount_tax_sold - gc.amount_gift_card, 2) as amount_sales, --similar to revenue
-  sum(line.amount_yotpo_discount) as amount_yotpo_discount,
-  sum(line.amount_standard_discount) as amount_standard_discount,
-  sum(line.amount_total_discount) as amount_total_discount,
+  round(o.amount_sold - o.amount_tax_sold - gc.amount_gift_card + line.amount_yotpo_discount, 2)  as amount_sales, --similar to revenue
+  line.amount_yotpo_discount,
+  line.amount_standard_discount,
+  line.amount_total_discount,
   coalesce(r.amount_refunded,0) as amount_refunded,
   o.created_at as order_created_timestamp,
   DATE(o.created_at) as order_created_date,
@@ -50,7 +64,7 @@ SELECT DISTINCT
   o.checkout_id as checkout_id_shopify
 FROM
   staging.shopify_orders o
-  LEFT OUTER JOIN fact.shopify_order_line line ON line.order_id_shopify = o.order_id_shopify and o.store = line.store
+  LEFT OUTER JOIN line_aggregates line ON line.order_id_shopify = o.order_id_shopify and o.store = line.store
   LEFT OUTER JOIN staging.shopify_order_shipping_line ship ON ship.order_id_shopify = o.order_id_shopify and o.store = ship.store
   LEFT OUTER JOIN gift_cards gc ON o.ORDER_ID_EDW = gc.ORDER_ID_EDW
   LEFT OUTER JOIN refunds r on o.order_id_shopify = r.order_id_shopify


### PR DESCRIPTION
Amount_sales needs to add back in yotpo discounts. Since yotpo discounts are revenue, unlike promo discounts.
ex. G3353662
currently amount sales = $65, but it should be $75
![image](https://github.com/user-attachments/assets/b78c403d-ed21-4f2d-b2fa-5015083f025b)


So we need to pre-aggregate shopify_order_line data, so we can add amount_yotpo_discount