### PR TITLE
making item_id_stord an array to solve for data splay issue

### DIFF
--- a/mozartdata/transforms/dim/product.sql
+++ b/mozartdata/transforms/dim/product.sql
@@ -146,7 +146,7 @@ SELECT DISTINCT
     prod_inv.sku
   , prod_inv.sku                                     AS product_id_edw
   , i.id                                             AS item_id_ns
-  , stord.id                                         AS item_id_stord
+  , array_agg(DISTINCT stord.id)                                         AS item_id_stord_array
   , prod_inv.product_id_d2c_shopify
   , prod_inv.product_id_b2b_shopify
   , prod_inv.product_id_goodrwill_shopify
@@ -253,3 +253,4 @@ FROM
     LEFT JOIN staging.shipstation_product shipstation
         ON shipstation.sku = prod_inv.sku
         AND shipstation.primary_item_id_flag = true
+    GROUP BY ALL

--- a/mozartdata/transforms/dim/product.sql
+++ b/mozartdata/transforms/dim/product.sql
@@ -146,7 +146,7 @@ SELECT DISTINCT
     prod_inv.sku
   , prod_inv.sku                                     AS product_id_edw
   , i.id                                             AS item_id_ns
-  , array_agg(DISTINCT stord.id)                                         AS item_id_stord_array
+  , array_agg(DISTINCT stord.id)                                         AS item_id_stord
   , prod_inv.product_id_d2c_shopify
   , prod_inv.product_id_b2b_shopify
   , prod_inv.product_id_goodrwill_shopify

--- a/mozartdata/transforms/dim/product.sql
+++ b/mozartdata/transforms/dim/product.sql
@@ -146,7 +146,7 @@ SELECT DISTINCT
     prod_inv.sku
   , prod_inv.sku                                     AS product_id_edw
   , i.id                                             AS item_id_ns
-  , array_agg(DISTINCT stord.id)                                         AS item_id_stord
+  , stord.id                                         AS item_id_stord
   , prod_inv.product_id_d2c_shopify
   , prod_inv.product_id_b2b_shopify
   , prod_inv.product_id_goodrwill_shopify
@@ -250,6 +250,7 @@ FROM
         ON i.id = agg.parentitem
     LEFT JOIN stord.stord_products_8589936822                      stord
         ON stord.sku = prod_inv.sku
+        and stord.type = 'item'
     LEFT JOIN staging.shipstation_product shipstation
         ON shipstation.sku = prod_inv.sku
         AND shipstation.primary_item_id_flag = true


### PR DESCRIPTION
On 12/18/2024, it was discovered that several skus now have multiple item_ids in stord. This is causing a single SKU to duplicate multiple times.

To fix this, we are converting item_id_stord to be an array, so we'll have a row per sku, but item_id_stord will now contain multiple IDs where needed. 