### PR TITLE
bring in 2024 tiers

### DIFF
--- a/mozartdata/transforms/fact/customer_ns_map.sql
+++ b/mozartdata/transforms/fact/customer_ns_map.sql
@@ -1,9 +1,13 @@
 SELECT
   cust.customer_id_edw,
-  nc.*
+  nc.*,
+  ct.tier as tier_2024
 FROM
   dim.CUSTOMER cust
 CROSS JOIN LATERAL FLATTEN(INPUT => cust.CUSTOMER_ID_NS) AS ns_ids
 LEFT OUTER JOIN
       staging.netsuite_customers nc
       ON nc.customer_id_ns = ns_ids.value
+LEFT OUTER JOIN
+    staging.customer_tier_snapshot_2024 ct
+    on cust.customer_id_edw = ct.customer_id_edw


### PR DESCRIPTION
This PR is to add tier_2024 to fact.customer_ns_map.

table updated on sandbox_db_josha
```
SELECT
  customer_id_edw
, tier
, tier_2024
from
  fact.customer_ns_map
where tier_2024 is not null
```
![image](https://github.com/user-attachments/assets/ef21f4b4-d15a-4985-a7a6-88b3e50d883d)

- [x] Row count test between prod and sandbox
```
SELECT
count(*)
from
  fact.customer_ns_map 
```

prod has ~~1666038~~ 1666486
sandbox has ~~166040~~ 1666486

This is because customer_id_edw = 'd6dad7de338ce20a072d8393f8695103' has 2 different customers in NS and different tiers. One for Dicks and one for Public Lands

Fixed on 1/15/2025
prod has 1666486
sandbox has 1666486


```
SELECT
customer_id_edw
, count(tier) c
from
  fact.customer_ns_map
group by all having c>1
```
This now returns 0 rows in prod and sandbox.