### PR TITLE
updating to map Patrick Temple to fleet feet

### DIFF
--- a/mozartdata/transforms/staging/netsuite_customers.sql
+++ b/mozartdata/transforms/staging/netsuite_customers.sql
@@ -58,7 +58,7 @@ SELECT cust.id                                                                 A
      coalesce(parent_tier.id,tiers.id) as tier_id_ns,
      coalesce(parent_tier.name,tiers.name) as tier_ns,
      case when coalesce(parent_tier.name,tiers.name) = 'Named' then
-       case when lower(cust.companyname) like '%fleet feet%' or lower(cust.email) like '%fleetfeet%' then 'Fleet Feet' else cust.companyname
+       case when lower(cust.companyname) like '%fleet feet%' or lower(cust.email) like '%fleetfeet%' or lower(cust.company_name) = 'patrick temple' then 'Fleet Feet' else cust.companyname
        end else coalesce(parent_tier.name,tiers.name)  end as tier,
      cust.custentityam_doors as doors,
      cust.custentityam_buyer_name as buyer_name,

--- a/mozartdata/transforms/staging/netsuite_customers.sql
+++ b/mozartdata/transforms/staging/netsuite_customers.sql
@@ -58,7 +58,7 @@ SELECT cust.id                                                                 A
      coalesce(parent_tier.id,tiers.id) as tier_id_ns,
      coalesce(parent_tier.name,tiers.name) as tier_ns,
      case when coalesce(parent_tier.name,tiers.name) = 'Named' then
-       case when lower(cust.companyname) like '%fleet feet%' or lower(cust.email) like '%fleetfeet%' or lower(cust.company_name) = 'patrick temple' then 'Fleet Feet' else cust.companyname
+       case when lower(cust.companyname) like '%fleet feet%' or lower(cust.email) like '%fleetfeet%' or lower(cust.companyname) = 'patrick temple' then 'Fleet Feet' else cust.companyname
        end else coalesce(parent_tier.name,tiers.name)  end as tier,
      cust.custentityam_doors as doors,
      cust.custentityam_buyer_name as buyer_name,


### PR DESCRIPTION
Jackson has some manual code to map some one off Fleet Feet stores to Fleet Feet tier. 

See Python Snippet below
```
b2b_data_filtered['tier'] = b2b_data_filtered['tier'].replace({
    'Castlerock Running': 'Fleet Feet',
    'Danny Crossett': 'Fleet Feet',
    'Rockwell Venture, LLC': 'Fleet Feet',
    'Montgomery Multisport': 'Fleet Feet',
    'Patrick Temple': 'Fleet Feet',
    'END MAX Sports Inc.': 'Fleet Feet'
})
```
We want to move that logic into the DWH.

Looking today, we have all of these mapped to Fleet Feet tier except Patrick Temple
![image](https://github.com/user-attachments/assets/69561077-180a-4b92-b91d-f5aa6537efa7)

This code fixed patrick temple