### PR TITLE
2025 performance media report

### DIFF
--- a/mozartdata/transforms/goodr_reporting/performance_media.sql
+++ b/mozartdata/transforms/goodr_reporting/performance_media.sql
@@ -216,4 +216,3 @@ SELECT
 
 FROM
   pre_to_date p
-WHERE p.year = 2025

--- a/mozartdata/transforms/goodr_reporting/performance_media_2025.sql
+++ b/mozartdata/transforms/goodr_reporting/performance_media_2025.sql
@@ -1,0 +1,10 @@
+/*
+  This report feeds the 2025 Performance Media google sheet
+
+ */
+SELECT
+  *
+from
+  goodr_reporting.performance_media
+where
+  year = 2025

--- a/mozartdata/transforms/goodr_reporting/performance_media_2025.sql
+++ b/mozartdata/transforms/goodr_reporting/performance_media_2025.sql
@@ -2,9 +2,8 @@
   This report feeds the 2025 Performance Media google sheet
 
  */
-SELECT
-  *
-from
+SELECT *
+FROM
   goodr_reporting.performance_media
-where
+WHERE
   year = 2025


### PR DESCRIPTION
This PR is focused on removing the 2025 year filter from goodr_reporting.performance_media and moving that to a dedicated report.