### PR TITLE
Patched fact.orders to have a coalesce on the quantity_fulfilled_ns c…

### DIFF
--- a/mozartdata/transforms/bridge/orders.sql
+++ b/mozartdata/transforms/bridge/orders.sql
@@ -1,401 +1,369 @@
 /*--first grab the netsuite info from dim.orders which implicitly should only
   have parent transactions from NS.
  */
-with
-    netsuite_info as (
-        select
-            orders.order_id_edw
-            , orders.transaction_id_ns       as parent_id
-            , line.channel
-            , category.currency_id_ns        as channel_currency_id_ns
-            , category.currency_abbreviation as channel_currency_abbreviation
-            , line.email
-            , line.customer_id_ns
-            , line.customer_id_edw
-            , line.tier
-            , line.location
-            , line.warranty_order_id_ns
-            , category.customer_category     as b2b_d2c
-            , category.model
-        from
-            dim.orders                       as orders
-        left outer join
-             fact.order_line                 as line
-             on
-                 line.transaction_id_ns = orders.transaction_id_ns
-        left outer join
-             dim.channel                     as category
-             on
-                 category.name = line.channel
-        where
-            /* no need for checking if its a parent as the only transaction_id_ns's
-               that are in dim.orders are parents
-             */
-             orders.transaction_id_ns is not null
-    )
-    , netsuite_aggregates as (
-        select distinct
-            ns_parent.order_id_edw
-            , ns_parent.parent_id
-            , ns_parent.channel
-            , ns_parent.channel_currency_id_ns
-            , ns_parent.channel_currency_abbreviation
-            , ns_parent.email
-            , ns_parent.customer_id_ns
-            , ns_parent.customer_id_edw
-            , ns_parent.tier
-            , ns_parent.location
-            , ns_parent.warranty_order_id_ns
-            , ns_parent.b2b_d2c
-            , ns_parent.model
-            , max(status_flag_edw) over ( partition by orderline.order_id_edw )                                                                                                     as status_flag_edw
-            , max(orderline.is_exchange) over ( partition by orderline.order_id_edw )                                                                                               as is_exchange
-            , first_value(transaction_date)
-                     over (
-                         partition by
-                             orderline.order_id_edw
-                         order by
-                             case
-                                when record_type = 'salesorder'
-                                then 1
-                                else 2
-                             end
-                             , transaction_created_timestamp_pst asc
-                     )                                         as booked_date
-            , first_value(case
-                         when orderline.record_type in ('cashsale', 'invoice')
-                             then orderline.transaction_date
-                         else null
-                     end) over (
-                         partition by
-                             orderline.order_id_edw
-                         order by
-                             case
-                                when orderline.record_type in ('cashsale', 'invoice')
-                                then 1
-                                else 2
-                             end
-                             , orderline.transaction_created_timestamp_pst asc
-                    )                                          as sold_date
-            , first_value(case
-                         when record_type = 'itemfulfillment'
-                             then transaction_date
-                         else null
-                     end) over (
-                         partition by
-                             orderline.order_id_edw
-                         order by
-                             case
-                                 when record_type = 'itemfulfillment'
-                                 then 1
-                                 else 2
-                             end
-                             , transaction_created_timestamp_pst desc
-                     )                                       as fulfillment_date
-            , first_value(shipping_window_start_date)
-                     ignore nulls over (
-                         partition by
-                             orderline.order_id_edw
-                         order by
-                             shipping_window_start_date desc
-                     )                                       as shipping_window_start_date
-            , first_value(shipping_window_end_date)
-                     ignore nulls over (
-                         partition by
-                             orderline.order_id_edw
-                         order by
-                             shipping_window_end_date desc
-                     )                                       as shipping_window_end_date
-        from
-            netsuite_info                                    as ns_parent
-        left outer join
-            fact.order_line                                  as orderline
-            on
-                orderline.order_id_edw = ns_parent.order_id_edw
-    )
-    , shopify_info as ( --Grab any and all shopify info from this CTE
-        select
-            orders.order_id_edw
-            , shopify.amount_booked                                                            as amount_product_booked_shop
-            , shopify.shipping_sold                                                            as amount_shipping_booked_shop
-            , shopify.amount_tax_sold                                                          as amount_tax_booked_shop
-            , shopify.amount_standard_discount                                                 as amount_discount_booked_shop
-            , (shopify.amount_booked + shopify.shipping_sold -
-                shopify.amount_standard_discount)                                              as amount_revenue_booked_shop
-            , (shopify.amount_booked + shopify.shipping_sold + shopify.amount_tax_sold -
-                shopify.amount_total_discount)                                                 as amount_paid_booked_shop
-            , shopify.order_created_date_pst
-            , shopify.quantity_booked                                                          as quantity_booked_shopify
-            , shopify.quantity_sold                                                            as quantity_sold_shopify
-        from
-            dim.orders                          orders
-        left outer join
-            fact.shopify_orders shopify
-            on
-                shopify.order_id_shopify = orders.order_id_shopify
-    )
-    , fulfillment_info as (
-        select
-             orders.order_id_edw
-            , sum(quantity_ns)    as total_quantity_ns
-            , sum(quantity_stord) as total_quantity_stord
-            , sum(quantity_ss)    as total_quantity_ss
-        from
-            dim.orders            as orders
-        left outer join
-            dim.fulfillment       as fulfill
-            on
-                fulfill.order_id_edw = orders.order_id_edw
-        left outer join
-            fact.fulfillment_item as fulfill_item
-            on
-                fulfill_item.fulfillment_id_edw = fulfill.fulfillment_id_edw
-        group by
-            orders.order_id_edw
-    )
-    , aggregates as (
-        select
-            oi.order_id_edw
-            , sum(
-                case
-                    when oi.plain_name not in ('Tax', 'Shipping')
-                    then oi.quantity_booked
-                    else 0
-                end
-            )                                      as quantity_booked
-            , sum(
-                case
-                    when oi.plain_name not in ('Tax', 'Shipping')
-                    then oi.quantity_sold
-                    else 0
-                end
-            )                                      as quantity_sold
-            , sum(
-                case
-                    when oi.plain_name not in ('Tax', 'Shipping')
-                    then oi.quantity_fulfilled
-                    else 0
-                end
-            )                                  as quantity_fulfilled
-            , sum(
-                case
-                    when oi.plain_name not in ('Tax', 'Shipping')
-                    then oi.quantity_refunded
-                    else 0
-                end
-            )                                  as quantity_refunded
-            , sum(
-                case
-                    when oi.plain_name not in ('Tax', 'Shipping')
-                    then oi.rate_booked
-                    else 0
-                end
-            )                                  as rate_booked
-            , sum(
-                case
-                    when oi.plain_name not in ('Tax', 'Shipping')
-                    then oi.rate_sold
-                    else 0
-                end
-            )                                  as rate_sold
-            , sum(
-                case
-                    when oi.plain_name not in ('Tax', 'Shipping')
-                    then oi.rate_refunded
-                    else 0
-                end
-            )                                  as rate_refunded
-            , sum(oi.amount_revenue_booked)    as amount_revenue_booked
-            , sum(oi.amount_product_booked)    as amount_product_booked
-            , sum(oi.amount_discount_booked)   as amount_discount_booked
-            , sum(oi.amount_shipping_booked)   as amount_shipping_booked
-            , sum(oi.amount_tax_booked)        as amount_tax_booked
-            , sum(oi.amount_paid_booked)       as amount_paid_booked
-            , sum(oi.amount_revenue_sold)      as amount_revenue_sold
-            , sum(oi.amount_product_sold)      as amount_product_sold
-            , sum(oi.amount_discount_sold)     as amount_discount_sold
-            , sum(oi.amount_shipping_sold)     as amount_shipping_sold
-            , sum(oi.amount_tax_sold)          as amount_tax_sold
-            , sum(oi.amount_paid_sold)         as amount_paid_sold
-            , sum(oi.amount_cogs_fulfilled)    as amount_cogs_fulfilled
-            , sum(oi.amount_revenue_refunded)  as amount_revenue_refunded
-            , sum(oi.amount_product_refunded)  as amount_product_refunded
-            , sum(oi.amount_shipping_refunded) as amount_shipping_refunded
-            , sum(oi.amount_tax_refunded)      as amount_tax_refunded
-            , sum(oi.amount_paid_refunded)     as amount_paid_refunded
-            , sum(oi.revenue)                  as revenue
-            , sum(oi.amount_paid_total)        as amount_paid_total
-            , sum(
-                case
-                    when oi.plain_name not in ('Tax', 'Shipping')
-                    then oi.gross_profit_estimate
-                    else 0
-                end
-            )                                  as gross_profit_estimate
-            , sum(
-                case
-                    when oi.plain_name not in ('Tax', 'Shipping')
-                    then oi.cost_estimate
-                    else 0
-                end
-            )                                   as cost_estimate
-        from
-            fact.order_item oi
-        group by
-            order_id_edw
-    )
-select
-    orders.order_id_edw
-    , orders.order_id_ns
-    , aggregate_netsuite.channel
-    , aggregate_netsuite.customer_id_ns
-    , aggregate_netsuite.customer_id_edw
-    , aggregate_netsuite.tier
-    , location.name                                                               as location
-    , aggregate_netsuite.warranty_order_id_ns
-    , coalesce(
-        --shopify shows first as it is considered the "booking" source of truth
-        shopify_info.order_created_date_pst
-        , aggregate_netsuite.booked_date
-    )                                             as booked_date
-    , shopify_info.order_created_date_pst                                         as booked_date_shopify
-    , aggregate_netsuite.booked_date                                              as booked_date_ns
-    , aggregate_netsuite.sold_date
-     --placeholders for rn for when we ad a fulfillment source of truth
-    , aggregate_netsuite.fulfillment_date                                         as fulfillment_date
-    , aggregate_netsuite.fulfillment_date                                         as fulfillment_date_ns
-    , aggregate_netsuite.shipping_window_start_date
-    , aggregate_netsuite.shipping_window_end_date
-    , aggregate_netsuite.is_exchange
-    , aggregate_netsuite.status_flag_edw
-    , b2b_d2c
-    , aggregate_netsuite.model
-    , coalesce(shopify_info.quantity_booked_shopify, aggregates.quantity_booked)  as quantity_booked-- source of truth column for quantities also comes from shopify
-    , shopify_info.quantity_booked_shopify                                        as quantity_booked_shopify
-    , aggregates.quantity_booked                                                  as quantity_booked_ns
-    , shopify_info.quantity_sold_shopify                                          as quantity_sold_shopify
-    , aggregates.quantity_sold                                                    as quantity_sold_ns
-    , aggregates.quantity_sold
-    , case
-        when aggregate_netsuite.channel not in (
-            'Key Account'
-            , 'Key Accounts'
-            , 'Global'
-            , 'Prescription'
-            , 'Key Account CAN'
-            , 'Amazon Canada'
-            , 'Amazon Prime'
-            , 'Cabana'
-            , 'Amazon'
-        )
-        then (
-            coalesce(
-                fulfillment_info.total_quantity_stord
-                , 0
-            ) + coalesce(
-                fulfillment_info.total_quantity_ss
-                , 0
-            )
-        )
-        else aggregates.quantity_fulfilled
-    end                                                                           as quantity_fulfilled--As per notes from our meeting, the idea is that on orders not in the channels, we dont want this column to show Netsuite IF information if its lacking from Stord/SS
-    , fulfillment_info.total_quantity_stord                                       as quantity_fulfilled_stord
-    , fulfillment_info.total_quantity_ss                                          as quantity_fulfilled_shipstation
-    , fulfillment_info.total_quantity_ns                                          as quantity_fulfilled_ns
-    , aggregates.quantity_refunded
-    , aggregates.quantity_refunded                                                as quantity_refunded_ns
-    , aggregates.rate_booked
-    , aggregates.rate_booked                                                      as rate_booked_ns
-    , aggregates.rate_sold
-    , aggregates.rate_refunded
-    , aggregates.rate_refunded                                                    as rate_refunded_ns
-    --shopify is also the source of truth for booking financial amount (SO's shouldnt matter GL wise anyways)
-    --converting shopify info from CAD to USD
-    --This sounds odd but it makes sense as shopify considers this "sold" but ns _sold is used to denote invoices and cash sales
-    , case
-        when aggregate_netsuite.channel_currency_abbreviation = 'CAD'
-        then shopify_info.amount_revenue_booked_shop * cer.exchange_rate
-        else shopify_info.amount_revenue_booked_shop
-    end                                                                           as amount_revenue_booked_shopify
-    , aggregates.amount_revenue_booked                                            as amount_revenue_booked_ns
-    , coalesce(amount_revenue_booked_shopify, amount_revenue_booked_ns)           as amount_revenue_booked
-    , case
-        when aggregate_netsuite.channel_currency_abbreviation = 'CAD'
-        then shopify_info.amount_revenue_booked_shop
-    end                                                                           as amount_revenue_booked_shopify_cad --this column shows the original CAD version of revenue, if applicable
-    , case
-        when aggregate_netsuite.channel_currency_abbreviation = 'CAD'
-        then shopify_info.amount_product_booked_shop * cer.exchange_rate
-        else shopify_info.amount_product_booked_shop
-    end                                                                           as amount_product_booked_shopify
-    , aggregates.amount_product_booked                                            as amount_product_booked_ns
-    , coalesce(amount_product_booked_shopify, amount_product_booked_ns)           as amount_product_booked
-    , case
-        when aggregate_netsuite.channel_currency_abbreviation = 'CAD'
-        then shopify_info.amount_discount_booked_shop * cer.exchange_rate
-        else shopify_info.amount_discount_booked_shop
-    end                                                                           as amount_discount_booked_shopify
-    , aggregates.amount_discount_booked                                           as amount_discount_booked_ns
-    , coalesce(amount_discount_booked_shopify, amount_discount_booked_ns)         as amount_discount_booked
-    , case
-        when aggregate_netsuite.channel_currency_abbreviation = 'CAD'
-        then shopify_info.amount_tax_booked_shop * cer.exchange_rate
-        else shopify_info.amount_tax_booked_shop
-    end                                                                           as amount_tax_booked_shopify
-    , aggregates.amount_tax_booked                                                as amount_tax_booked_ns
-    , coalesce(shopify_info.amount_tax_booked_shop, aggregates.amount_tax_booked) as amount_tax_booked
-    , case
-        when aggregate_netsuite.channel_currency_abbreviation = 'CAD'
-        then shopify_info.amount_shipping_booked_shop * cer.exchange_rate
-        else shopify_info.amount_shipping_booked_shop
-    end                                                                           as amount_shipping_booked_shopify
-    , aggregates.amount_shipping_booked                                           as amount_shipping_booked_ns
-    , coalesce(amount_shipping_booked_shopify, amount_shipping_booked_ns)         as amount_shipping_booked
-    , case
-        when aggregate_netsuite.channel_currency_abbreviation = 'CAD'
-        then shopify_info.amount_paid_booked_shop * cer.exchange_rate
-        else shopify_info.amount_paid_booked_shop
-    end                                                                           as amount_paid_booked_shopify
-    , aggregates.amount_paid_booked                                               as amount_paid_booked_ns
-    , coalesce(amount_paid_booked_shopify, amount_paid_booked_ns)                 as amount_paid_booked
-    , aggregates.amount_revenue_sold
-    , aggregates.amount_product_sold
-    , aggregates.amount_discount_sold
-    , aggregates.amount_shipping_sold
-    , aggregates.amount_tax_sold
-    , aggregates.amount_paid_sold
-    , aggregates.amount_cogs_fulfilled
-    , aggregates.amount_revenue_refunded
-    , aggregates.amount_product_refunded
-    , aggregates.amount_shipping_refunded
-    , aggregates.amount_tax_refunded
-    , aggregates.amount_paid_refunded
-    , aggregates.revenue
-    , aggregates.amount_paid_total
-    , aggregates.gross_profit_estimate
-    , aggregates.cost_estimate
+WITH netsuite_info AS (SELECT orders.order_id_edw
+							, orders.transaction_id_ns       AS parent_id
+							, line.channel
+							, category.currency_id_ns        AS channel_currency_id_ns
+							, category.currency_abbreviation AS channel_currency_abbreviation
+							, line.email
+							, line.customer_id_ns
+							, line.customer_id_edw
+							, line.tier
+							, line.location
+							, line.warranty_order_id_ns
+							, category.customer_category     AS b2b_d2c
+							, category.model
+					   FROM dim.orders AS orders
+								LEFT OUTER JOIN
+							fact.order_line AS line
+							ON
+								line.transaction_id_ns = orders.transaction_id_ns
+								LEFT OUTER JOIN
+							dim.channel AS category
+							ON
+								category.name = line.channel
+					   WHERE
+						   /* no need for checking if its a parent as the only transaction_id_ns's
+							  that are in dim.orders are parents
+							*/
+						   orders.transaction_id_ns IS NOT NULL)
+   , netsuite_aggregates AS (SELECT DISTINCT ns_parent.order_id_edw
+										   , ns_parent.parent_id
+										   , ns_parent.channel
+										   , ns_parent.channel_currency_id_ns
+										   , ns_parent.channel_currency_abbreviation
+										   , ns_parent.email
+										   , ns_parent.customer_id_ns
+										   , ns_parent.customer_id_edw
+										   , ns_parent.tier
+										   , ns_parent.location
+										   , ns_parent.warranty_order_id_ns
+										   , ns_parent.b2b_d2c
+										   , ns_parent.model
+										   , MAX(status_flag_edw) OVER ( PARTITION BY orderline.order_id_edw )       AS status_flag_edw
+										   , MAX(orderline.is_exchange) OVER ( PARTITION BY orderline.order_id_edw ) AS is_exchange
+										   , FIRST_VALUE(transaction_date)
+														 OVER (
+															 PARTITION BY
+																 orderline.order_id_edw
+															 ORDER BY
+																 CASE
+																	 WHEN record_type = 'salesorder'
+																		 THEN 1
+																	 ELSE 2
+																	 END
+																 , transaction_created_timestamp_pst ASC
+															 )                                                       AS booked_date
+										   , FIRST_VALUE(CASE
+															 WHEN orderline.record_type IN ('cashsale', 'invoice')
+																 THEN orderline.transaction_date
+															 ELSE NULL
+															 END) OVER (
+															 PARTITION BY
+																 orderline.order_id_edw
+															 ORDER BY
+																 CASE
+																	 WHEN orderline.record_type IN ('cashsale', 'invoice')
+																		 THEN 1
+																	 ELSE 2
+																	 END
+																 , orderline.transaction_created_timestamp_pst ASC
+															 )                                                       AS sold_date
+										   , FIRST_VALUE(CASE
+															 WHEN record_type = 'itemfulfillment'
+																 THEN transaction_date
+															 ELSE NULL
+															 END) OVER (
+															 PARTITION BY
+																 orderline.order_id_edw
+															 ORDER BY
+																 CASE
+																	 WHEN record_type = 'itemfulfillment'
+																		 THEN 1
+																	 ELSE 2
+																	 END
+																 , transaction_created_timestamp_pst DESC
+															 )                                                       AS fulfillment_date
+										   , FIRST_VALUE(shipping_window_start_date)
+														 IGNORE NULLS OVER (
+															 PARTITION BY
+																 orderline.order_id_edw
+															 ORDER BY
+																 shipping_window_start_date DESC
+															 )                                                       AS shipping_window_start_date
+										   , FIRST_VALUE(shipping_window_end_date)
+														 IGNORE NULLS OVER (
+															 PARTITION BY
+																 orderline.order_id_edw
+															 ORDER BY
+																 shipping_window_end_date DESC
+															 )                                                       AS shipping_window_end_date
+							 FROM netsuite_info AS ns_parent
+									  LEFT OUTER JOIN
+								  fact.order_line AS orderline
+								  ON
+									  orderline.order_id_edw = ns_parent.order_id_edw)
+   , shopify_info AS ( --Grab any and all shopify info from this CTE
+	SELECT orders.order_id_edw
+		 , shopify.amount_booked              AS amount_product_booked_shop
+		 , shopify.shipping_sold              AS amount_shipping_booked_shop
+		 , shopify.amount_tax_sold            AS amount_tax_booked_shop
+		 , shopify.amount_standard_discount   AS amount_discount_booked_shop
+		 , (shopify.amount_booked + shopify.shipping_sold -
+			shopify.amount_standard_discount) AS amount_revenue_booked_shop
+		 , (shopify.amount_booked + shopify.shipping_sold + shopify.amount_tax_sold -
+			shopify.amount_total_discount)    AS amount_paid_booked_shop
+		 , shopify.order_created_date_pst
+		 , shopify.quantity_booked            AS quantity_booked_shopify
+		 , shopify.quantity_sold              AS quantity_sold_shopify
+	FROM dim.orders orders
+			 LEFT OUTER JOIN
+		 fact.shopify_orders shopify
+		 ON
+			 shopify.order_id_shopify = orders.order_id_shopify)
+   , fulfillment_info AS (SELECT orders.order_id_edw
+							   , SUM(quantity_ns)    AS total_quantity_ns
+							   , SUM(quantity_stord) AS total_quantity_stord
+							   , SUM(quantity_ss)    AS total_quantity_ss
+						  FROM dim.orders AS orders
+								   LEFT OUTER JOIN
+							   dim.fulfillment AS fulfill
+							   ON
+								   fulfill.order_id_edw = orders.order_id_edw
+								   LEFT OUTER JOIN
+							   fact.fulfillment_item AS fulfill_item
+							   ON
+								   fulfill_item.fulfillment_id_edw = fulfill.fulfillment_id_edw
+						  GROUP BY orders.order_id_edw)
+   , aggregates AS (SELECT oi.order_id_edw
+						 , SUM(
+			CASE
+				WHEN oi.plain_name NOT IN ('Tax', 'Shipping')
+					THEN oi.quantity_booked
+				ELSE 0
+				END
+						   )                                AS quantity_booked
+						 , SUM(
+			CASE
+				WHEN oi.plain_name NOT IN ('Tax', 'Shipping')
+					THEN oi.quantity_sold
+				ELSE 0
+				END
+						   )                                AS quantity_sold
+						 , SUM(
+			CASE
+				WHEN oi.plain_name NOT IN ('Tax', 'Shipping')
+					THEN oi.quantity_fulfilled
+				ELSE 0
+				END
+						   )                                AS quantity_fulfilled
+						 , SUM(
+			CASE
+				WHEN oi.plain_name NOT IN ('Tax', 'Shipping')
+					THEN oi.quantity_refunded
+				ELSE 0
+				END
+						   )                                AS quantity_refunded
+						 , SUM(
+			CASE
+				WHEN oi.plain_name NOT IN ('Tax', 'Shipping')
+					THEN oi.rate_booked
+				ELSE 0
+				END
+						   )                                AS rate_booked
+						 , SUM(
+			CASE
+				WHEN oi.plain_name NOT IN ('Tax', 'Shipping')
+					THEN oi.rate_sold
+				ELSE 0
+				END
+						   )                                AS rate_sold
+						 , SUM(
+			CASE
+				WHEN oi.plain_name NOT IN ('Tax', 'Shipping')
+					THEN oi.rate_refunded
+				ELSE 0
+				END
+						   )                                AS rate_refunded
+						 , SUM(oi.amount_revenue_booked)    AS amount_revenue_booked
+						 , SUM(oi.amount_product_booked)    AS amount_product_booked
+						 , SUM(oi.amount_discount_booked)   AS amount_discount_booked
+						 , SUM(oi.amount_shipping_booked)   AS amount_shipping_booked
+						 , SUM(oi.amount_tax_booked)        AS amount_tax_booked
+						 , SUM(oi.amount_paid_booked)       AS amount_paid_booked
+						 , SUM(oi.amount_revenue_sold)      AS amount_revenue_sold
+						 , SUM(oi.amount_product_sold)      AS amount_product_sold
+						 , SUM(oi.amount_discount_sold)     AS amount_discount_sold
+						 , SUM(oi.amount_shipping_sold)     AS amount_shipping_sold
+						 , SUM(oi.amount_tax_sold)          AS amount_tax_sold
+						 , SUM(oi.amount_paid_sold)         AS amount_paid_sold
+						 , SUM(oi.amount_cogs_fulfilled)    AS amount_cogs_fulfilled
+						 , SUM(oi.amount_revenue_refunded)  AS amount_revenue_refunded
+						 , SUM(oi.amount_product_refunded)  AS amount_product_refunded
+						 , SUM(oi.amount_shipping_refunded) AS amount_shipping_refunded
+						 , SUM(oi.amount_tax_refunded)      AS amount_tax_refunded
+						 , SUM(oi.amount_paid_refunded)     AS amount_paid_refunded
+						 , SUM(oi.revenue)                  AS revenue
+						 , SUM(oi.amount_paid_total)        AS amount_paid_total
+						 , SUM(
+			CASE
+				WHEN oi.plain_name NOT IN ('Tax', 'Shipping')
+					THEN oi.gross_profit_estimate
+				ELSE 0
+				END
+						   )                                AS gross_profit_estimate
+						 , SUM(
+			CASE
+				WHEN oi.plain_name NOT IN ('Tax', 'Shipping')
+					THEN oi.cost_estimate
+				ELSE 0
+				END
+						   )                                AS cost_estimate
+					FROM fact.order_item oi
+					GROUP BY order_id_edw)
+SELECT orders.order_id_edw
+	 , orders.order_id_ns
+	 , aggregate_netsuite.channel
+	 , aggregate_netsuite.customer_id_ns
+	 , aggregate_netsuite.customer_id_edw
+	 , aggregate_netsuite.tier
+	 , location.name                                                               AS location
+	 , aggregate_netsuite.warranty_order_id_ns
+	 , COALESCE(
+	--shopify shows first as it is considered the "booking" source of truth
+		shopify_info.order_created_date_pst
+	, aggregate_netsuite.booked_date
+	   )                                                                           AS booked_date
+	 , shopify_info.order_created_date_pst                                         AS booked_date_shopify
+	 , aggregate_netsuite.booked_date                                              AS booked_date_ns
+	 , aggregate_netsuite.sold_date
+	 --placeholders for rn for when we ad a fulfillment source of truth
+	 , aggregate_netsuite.fulfillment_date                                         AS fulfillment_date
+	 , aggregate_netsuite.fulfillment_date                                         AS fulfillment_date_ns
+	 , aggregate_netsuite.shipping_window_start_date
+	 , aggregate_netsuite.shipping_window_end_date
+	 , aggregate_netsuite.is_exchange
+	 , aggregate_netsuite.status_flag_edw
+	 , b2b_d2c
+	 , aggregate_netsuite.model
+	 , COALESCE(shopify_info.quantity_booked_shopify, aggregates.quantity_booked)  AS quantity_booked-- source of truth column for quantities also comes from shopify
+	 , shopify_info.quantity_booked_shopify                                        AS quantity_booked_shopify
+	 , aggregates.quantity_booked                                                  AS quantity_booked_ns
+	 , shopify_info.quantity_sold_shopify                                          AS quantity_sold_shopify
+	 , aggregates.quantity_sold                                                    AS quantity_sold_ns
+	 , aggregates.quantity_sold
+	 , CASE
+		   WHEN aggregate_netsuite.channel NOT IN (
+												   'Key Account', 'Key Accounts', 'Global', 'Prescription',
+												   'Key Account CAN', 'Amazon Canada', 'Amazon Prime', 'Cabana',
+												   'Amazon'
+			   )
+			   THEN (
+			   COALESCE(
+					   fulfillment_info.total_quantity_stord
+				   , 0
+			   ) + COALESCE(
+					   fulfillment_info.total_quantity_ss
+				   , 0
+				   )
+			   )
+		   ELSE aggregates.quantity_fulfilled
+	END                                                                            AS quantity_fulfilled--As per notes from our meeting, the idea is that on orders not in the channels, we dont want this column to show Netsuite IF information if its lacking from Stord/SS
+	 , fulfillment_info.total_quantity_stord                                       AS quantity_fulfilled_stord
+	 , fulfillment_info.total_quantity_ss                                          AS quantity_fulfilled_shipstation
+	 , COALESCE(fulfillment_info.total_quantity_ns, aggregates.quantity_fulfilled) AS quantity_fulfilled_ns --This is a coalesce so that at least fact.orders will see that there is a quantity fulfilled, even if there is no tracking number
+	 , aggregates.quantity_refunded
+	 , aggregates.quantity_refunded                                                AS quantity_refunded_ns
+	 , aggregates.rate_booked
+	 , aggregates.rate_booked                                                      AS rate_booked_ns
+	 , aggregates.rate_sold
+	 , aggregates.rate_refunded
+	 , aggregates.rate_refunded                                                    AS rate_refunded_ns
+	 --shopify is also the source of truth for booking financial amount (SO's shouldnt matter GL wise anyways)
+	 --converting shopify info from CAD to USD
+	 --This sounds odd but it makes sense as shopify considers this "sold" but ns _sold is used to denote invoices and cash sales
+	 , CASE
+		   WHEN aggregate_netsuite.channel_currency_abbreviation = 'CAD'
+			   THEN shopify_info.amount_revenue_booked_shop * cer.exchange_rate
+		   ELSE shopify_info.amount_revenue_booked_shop
+	END                                                                            AS amount_revenue_booked_shopify
+	 , aggregates.amount_revenue_booked                                            AS amount_revenue_booked_ns
+	 , COALESCE(amount_revenue_booked_shopify, amount_revenue_booked_ns)           AS amount_revenue_booked
+	 , CASE
+		   WHEN aggregate_netsuite.channel_currency_abbreviation = 'CAD'
+			   THEN shopify_info.amount_revenue_booked_shop
+	END                                                                            AS amount_revenue_booked_shopify_cad --this column shows the original CAD version of revenue, if applicable
+	 , CASE
+		   WHEN aggregate_netsuite.channel_currency_abbreviation = 'CAD'
+			   THEN shopify_info.amount_product_booked_shop * cer.exchange_rate
+		   ELSE shopify_info.amount_product_booked_shop
+	END                                                                            AS amount_product_booked_shopify
+	 , aggregates.amount_product_booked                                            AS amount_product_booked_ns
+	 , COALESCE(amount_product_booked_shopify, amount_product_booked_ns)           AS amount_product_booked
+	 , CASE
+		   WHEN aggregate_netsuite.channel_currency_abbreviation = 'CAD'
+			   THEN shopify_info.amount_discount_booked_shop * cer.exchange_rate
+		   ELSE shopify_info.amount_discount_booked_shop
+	END                                                                            AS amount_discount_booked_shopify
+	 , aggregates.amount_discount_booked                                           AS amount_discount_booked_ns
+	 , COALESCE(amount_discount_booked_shopify, amount_discount_booked_ns)         AS amount_discount_booked
+	 , CASE
+		   WHEN aggregate_netsuite.channel_currency_abbreviation = 'CAD'
+			   THEN shopify_info.amount_tax_booked_shop * cer.exchange_rate
+		   ELSE shopify_info.amount_tax_booked_shop
+	END                                                                            AS amount_tax_booked_shopify
+	 , aggregates.amount_tax_booked                                                AS amount_tax_booked_ns
+	 , COALESCE(shopify_info.amount_tax_booked_shop, aggregates.amount_tax_booked) AS amount_tax_booked
+	 , CASE
+		   WHEN aggregate_netsuite.channel_currency_abbreviation = 'CAD'
+			   THEN shopify_info.amount_shipping_booked_shop * cer.exchange_rate
+		   ELSE shopify_info.amount_shipping_booked_shop
+	END                                                                            AS amount_shipping_booked_shopify
+	 , aggregates.amount_shipping_booked                                           AS amount_shipping_booked_ns
+	 , COALESCE(amount_shipping_booked_shopify, amount_shipping_booked_ns)         AS amount_shipping_booked
+	 , CASE
+		   WHEN aggregate_netsuite.channel_currency_abbreviation = 'CAD'
+			   THEN shopify_info.amount_paid_booked_shop * cer.exchange_rate
+		   ELSE shopify_info.amount_paid_booked_shop
+	END                                                                            AS amount_paid_booked_shopify
+	 , aggregates.amount_paid_booked                                               AS amount_paid_booked_ns
+	 , COALESCE(amount_paid_booked_shopify, amount_paid_booked_ns)                 AS amount_paid_booked
+	 , aggregates.amount_revenue_sold
+	 , aggregates.amount_product_sold
+	 , aggregates.amount_discount_sold
+	 , aggregates.amount_shipping_sold
+	 , aggregates.amount_tax_sold
+	 , aggregates.amount_paid_sold
+	 , aggregates.amount_cogs_fulfilled
+	 , aggregates.amount_revenue_refunded
+	 , aggregates.amount_product_refunded
+	 , aggregates.amount_shipping_refunded
+	 , aggregates.amount_tax_refunded
+	 , aggregates.amount_paid_refunded
+	 , aggregates.revenue
+	 , aggregates.amount_paid_total
+	 , aggregates.gross_profit_estimate
+	 , aggregates.cost_estimate
 -- case when aggregate_netsuite.tier like '%O' then true
 --      when cust.first_order_id_edw_ns is not null and cust.customer_category = 'D2C' then TRUE
 --      else false end as customer_first_order_flag
-from
-    dim.orders                                  orders
-left outer join netsuite_aggregates as aggregate_netsuite
-    on aggregate_netsuite.order_id_edw = orders.order_id_edw
-left outer join shopify_info
-    on shopify_info.order_id_edw = orders.order_id_edw
-left outer join aggregates
-    on aggregates.order_id_edw = aggregate_netsuite.order_id_edw
-left outer join dim.location                    location
-    on location.location_id_ns = aggregate_netsuite.location
-left outer join fact.currency_exchange_rate      cer
-    on aggregate_netsuite.booked_date = cer.effective_date and
-       aggregate_netsuite.channel_currency_id_ns = cer.transaction_currency_id_ns
-left outer join fulfillment_info
-    on fulfillment_info.order_id_edw = orders.order_id_edw
+FROM dim.orders orders
+		 LEFT OUTER JOIN netsuite_aggregates AS aggregate_netsuite
+						 ON aggregate_netsuite.order_id_edw = orders.order_id_edw
+		 LEFT OUTER JOIN shopify_info
+						 ON shopify_info.order_id_edw = orders.order_id_edw
+		 LEFT OUTER JOIN aggregates
+						 ON aggregates.order_id_edw = aggregate_netsuite.order_id_edw
+		 LEFT OUTER JOIN dim.location location
+						 ON location.location_id_ns = aggregate_netsuite.location
+		 LEFT OUTER JOIN fact.currency_exchange_rate cer
+						 ON aggregate_netsuite.booked_date = cer.effective_date AND
+							aggregate_netsuite.channel_currency_id_ns = cer.transaction_currency_id_ns
+		 LEFT OUTER JOIN fulfillment_info
+						 ON fulfillment_info.order_id_edw = orders.order_id_edw
 -- LEFT OUTER JOIN fact.customers cust ON cust.first_order_id_edw_ns = orders.order_id_edw
-where
-    aggregate_netsuite.booked_date >= '2022-01-01T00:00:00Z'
-order by
-    aggregate_netsuite.booked_date desc
+WHERE aggregate_netsuite.booked_date >= '2022-01-01T00:00:00Z' and orders.order_id_edw = 'G2089287'
+ORDER BY aggregate_netsuite.booked_date DESC
 
 


### PR DESCRIPTION
…olumn. This is because beforehand if there was no tracking number on the IF, it would show "O qty fulfilled NS" even though this is wrong.