### PR TITLE
Update klaviyo tables

### DIFF
--- a/mozartdata/transforms/dim/klaviyo_metrics.sql
+++ b/mozartdata/transforms/dim/klaviyo_metrics.sql
@@ -7,16 +7,31 @@ so the decision was made to just start fresh in 2024 with Portable.
 Transforms: all dates are natively in UTC, so I converted them to LA time.
 About this data: Klaviyo Metrics are the various customer actions tracked in Klaviyo. To view the
 activity use fact.klaivyo_events.
+
+Update: 2/16/2025
+We are migrating from v2 to v3 of the API. Updating code to align with the new data model.
 */
+WITH
+  base as
+    (
+      SELECT
+        to_timestamp(m.attributes:CREATED) as created_timestamp
+      , to_timestamp(m.attributes:UPDATED) as updated_timestamp
+      , m.*
+      FROM
+        klaviyo_portable_v3_parallel.klaviyo_v3_metrics_8589938396 m
+    )
 SELECT
-  m.created as created_timestamp
-, date(m.created) as created_date
-, convert_timezone('UTC', 'America/Los_Angeles', m.created) as created_timestamp_pst
-, date(convert_timezone('UTC', 'America/Los_Angeles', m.created)) as created_date_pst
-, m.metric_id as metric_id_klaviyo
-, m.name as name
+    b.id as metric_id_klaviyo
+  , b.created_timestamp
+  , date(b.created_timestamp) as created_date
+  , convert_timezone('UTC', 'America/Los_Angeles', b.created_timestamp) as created_timestamp_pst
+  , date(convert_timezone('UTC', 'America/Los_Angeles', b.created_timestamp)) as created_date_pst
+  , b.attributes:NAME::text as name
+  , b.updated_timestamp
+  , date(b.updated_timestamp) as updated_date
 FROM
-  klaviyo_portable.klaviyo_v2_metrics_8589937320 m
+  base b
 /*
 Note: The second half of the union was joining to the original fivetran data pulled from
 July 2023 - Jan 2024. However,  this data was incomplete and inconsistent with Portable's data

--- a/mozartdata/transforms/staging/klaviyo_events.sql
+++ b/mozartdata/transforms/staging/klaviyo_events.sql
@@ -1,10 +1,9 @@
 SELECT
-  _portable_extracted,
-  datetime,
-  event_id,
-  event_properties,
-  metric_id,
-  profile_id,
+   _portable_extracted,
+   attributes,
+   id as event_id,
+   links,
+   relationships,
   timestamp,
-  uuid
-FROM klaviyo_portable.klaviyo_v2_events_8589937320
+  type
+FROM  klaviyo_portable_v3_parallel.klaviyo_v3_events_8589938396


### PR DESCRIPTION
# Overview
We are moving from v2 API to v3 of the Klaviyo API via Portable.

There are substantial data model changes, so we will need to revamp all of our klaviyo tables to match.

# Tables
## dim
- [x] dim.klaviyo_metrics
old:
![image](https://github.com/user-attachments/assets/9b6b0695-c32c-437c-8e92-011cb418476d)
new:
![image](https://github.com/user-attachments/assets/370f4071-7abe-4b65-82bc-f77acbd7da9c)

## staging
## fact