### PR TITLE
Update New vs Existing logic

### DIFF
--- a/mozartdata/transforms/dev_reporting/gl_transaction.sql
+++ b/mozartdata/transforms/dev_reporting/gl_transaction.sql
@@ -43,12 +43,8 @@ SELECT DISTINCT
 , gt.cleared_date
 , gt.order_id_shopify
 , o.new_customer_order_flag
-, o.new_customer_order_flag
 FROM
   fact.gl_transaction gt
   LEFT JOIN
     fact.orders o
   ON o.order_id_edw = gt.order_id_edw
-  LEFT OUTER JOIN fact.customers cust
-    ON cust.first_order_id_edw_shopify = gt.order_id_edw
-    AND cust.customer_category = 'D2C'

--- a/mozartdata/transforms/dev_reporting/gl_transaction.sql
+++ b/mozartdata/transforms/dev_reporting/gl_transaction.sql
@@ -28,7 +28,8 @@ SELECT DISTINCT
 , gt.product_id_edw
 , gt.customer_id_ns
 , gt.customer_id_edw
-, gt.tier
+, gt.customer_tier
+, o.tier as order_tier
 , gt.department_id_ns
 , gt.department
 , gt.memo
@@ -41,15 +42,13 @@ SELECT DISTINCT
 , gt.cleared_flag
 , gt.cleared_date
 , gt.order_id_shopify
-, CASE
-    WHEN o.tier LIKE '%O' AND o.b2b_d2c = 'B2B' THEN TRUE
-    WHEN cust.first_order_id_edw_shopify IS NOT NULL THEN TRUE
-    ELSE FALSE END AS new_customer_order_flag
+, o.new_customer_order_flag
+, o.new_customer_order_flag
 FROM
   fact.gl_transaction gt
   LEFT JOIN
     fact.orders o
   ON o.order_id_edw = gt.order_id_edw
   LEFT OUTER JOIN fact.customers cust
-  ON cust.first_order_id_edw_shopify = gt.order_id_edw
-  AND cust.customer_category = 'D2C'
+    ON cust.first_order_id_edw_shopify = gt.order_id_edw
+    AND cust.customer_category = 'D2C'

--- a/mozartdata/transforms/fact/customers.sql
+++ b/mozartdata/transforms/fact/customers.sql
@@ -13,7 +13,7 @@ WITH
       , SUM(o.amount_revenue_sold) OVER (PARTITION BY o.customer_id_edw)                             AS lifetime_revenue
       , SUM(o.amount_revenue_sold) OVER (PARTITION BY o.customer_id_edw, c.customer_category)        AS channel_revenue
       FROM
-        fact.orders o
+        bridge.orders o
         LEFT JOIN
           dim.channel c
           ON o.channel = c.name

--- a/mozartdata/transforms/fact/gl_transaction.sql
+++ b/mozartdata/transforms/fact/gl_transaction.sql
@@ -53,7 +53,7 @@ use createdate converted instead of trandate
     , p.product_id_edw
     , tran.entity as customer_id_ns
     , cnm.customer_id_edw
-    , cnm.tier
+    , cnm.tier as customer_tier
     , tl.department as department_id_ns
     , d.name as department
     , tran.memo as memo

--- a/mozartdata/transforms/fact/orders.sql
+++ b/mozartdata/transforms/fact/orders.sql
@@ -92,6 +92,7 @@ select
     , refund.refund_timestamp_pst
     , date(refund.refund_timestamp_pst)                                                  as refund_date_pst
     , CASE
+        WHEN o.b2b_d2c = 'INDIRECT' THEN NULL
         WHEN o.tier LIKE '%O' AND o.b2b_d2c = 'B2B' THEN TRUE
         WHEN cust.first_order_id_edw_shopify IS NOT NULL THEN TRUE
         ELSE FALSE END AS new_customer_order_flag

--- a/mozartdata/transforms/fact/orders.sql
+++ b/mozartdata/transforms/fact/orders.sql
@@ -91,9 +91,16 @@ select
     end                          as has_refund
     , refund.refund_timestamp_pst
     , date(refund.refund_timestamp_pst)                                                  as refund_date_pst
+    , CASE
+        WHEN o.tier LIKE '%O' AND o.b2b_d2c = 'B2B' THEN TRUE
+        WHEN cust.first_order_id_edw_shopify IS NOT NULL THEN TRUE
+        ELSE FALSE END AS new_customer_order_flag
 from
     bridge.orders as o
 left outer join
     refund_aggregates               refund
     on
         refund.order_id_edw = o.order_id_edw
+  LEFT OUTER JOIN fact.customers cust
+    ON cust.first_order_id_edw_shopify = o.order_id_edw
+    AND cust.customer_category = 'D2C'


### PR DESCRIPTION
# Issue
Gabby requested: 
1. we align dev_reporting.gl_transaction tier with the tier from the order at the time
2. add New vs Existing to fact.orders
3. Align dev_reporting.gl_transaction for NvE

--- updated requirement found during QC
4. set new_customer_order_flag = NULL for INDIRECT

# Solution
In order to do this we need to make a few changes to the pipeline to prevent circular references.
As part of #102 @goodrsamwise implemented a bridge.orders table to sit before fact.orders. This allowed us to use this table instead of fact.orders to report on orders information in dev_reporting.gl_transaction. Namely reporting on NvE customers.

We can now refer to this table instead of fact.orders in fact.customers, so we can then land NvE in fact.orders.

- [x] update fact.customers to use bridge.orders
- [x] update fact.orders to have a `new_customer_order_flag` -> which will be based on if this is the first order for D2C, or using tier logic for B2B
- [x] update dev_reporting.gl_transaction to use the tier from fact.orders, NOT from customers. 
- [x] update fact.order_item_detail to NULL new_customer_order_flag for INDIRECT

# QC
Prior to updating tables in sandbox, I cloned `prod_goodr_dwh` to `sandbox_db_josha`
## fact.customers
### row count check ✔️ 
```
select
  'prod_goodr_dwh.fact.customers' as tbl,
  count(*) as row_cnt
from
  prod_goodr_dwh.fact.customers
group by all
union all
select
  'sandbox_db_josha.fact.customers' as tbl,
  count(*) as row_cnt
from
  sandbox_db_josha.fact.customers
group by all
```
![image](https://github.com/user-attachments/assets/9f905730-863c-4140-b7e9-2541bcc34e00)

## fact.orders
### row count check ✔️ 
```
select
  'prod_goodr_dwh.fact.orders' as tbl,
  count(*) as row_cnt
from
  prod_goodr_dwh.fact.orders
group by all
union all
select
  'sandbox_db_josha.fact.orders' as tbl,
  count(*) as row_cnt
from
  sandbox_db_josha.fact.orders
group by all
````
![image](https://github.com/user-attachments/assets/cc7f0961-0188-4113-ab38-d008bcf003b6)
### 1 row per order_id_edw:
```
select
  order_id_edw,
  count(*) as row_cnt
from
  sandbox_db_josha.fact.orders
group by all
having row_cnt >1
```
![image](https://github.com/user-attachments/assets/b73eaea7-cf9e-4b4c-b477-3a11876b6bf2)
This issue exists in prod as well... Investigating

### confirm tier hasn't changed ✔️ 
```
select
  *
from
  prod_goodr_dwh.fact.orders o
inner join
  sandbox_db_josha.fact.orders n
  on o.order_id_edw = n.order_id_edw
where o.tier != n.tier
```
No rows! 

### validate tiers and NvE looks correct ✔️ 
```
select
  o.tier
, year(o.sold_date) sold_year
, o.new_customer_order_flag
, count(*)
from
  sandbox_db_josha.fact.orders o
where tier is not null
group by all
order by
sold_year asc, tier asc, new_customer_order_flag
```

## fact.gl_transaction
### small change but worth ensuring no data change ✔️ 
```
SELECT
  'prod_goodr_dwh.fact.gl_transaction' AS tbl
, COUNT(*)                     AS row_cnt
FROM
  prod_goodr_dwh.fact.gl_transaction
GROUP BY ALL
UNION ALL
SELECT
  'sandbox_db_josha.fact.gl_transaction' AS tbl
, COUNT(*)                       AS row_cnt
FROM
  sandbox_db_josha.fact.gl_transaction
GROUP BY ALL
```
![image](https://github.com/user-attachments/assets/6ba2ffb3-a0e9-4927-8b65-244be025b506)

## dev_reporting.gl_transaction
### small change but worth ensuring no data change ✔️ 
```
SELECT
  'prod_goodr_dwh.fact.gl_transaction' AS tbl
, COUNT(*)                     AS row_cnt
FROM
  prod_goodr_dwh.fact.gl_transaction
GROUP BY ALL
UNION ALL
SELECT
  'sandbox_db_josha.fact.gl_transaction' AS tbl
, COUNT(*)                       AS row_cnt
FROM
  sandbox_db_josha.fact.gl_transaction
GROUP BY ALL
```
![image](https://github.com/user-attachments/assets/8595c297-c75a-42bc-a79b-132cb07eaaff)

### validate alignment between tier for dev report and orders ✔️ 
prod:
```
select
count(*) --695823
from
  prod_goodr_dwh.fact.orders o
left join
  prod_goodr_dwh.dev_reporting.gl_transaction g
  on o.order_id_edw = g.order_id_edw
where o.tier != g.tier
```
```
select
count(*) --0
from
  sandbox_db_josha.fact.orders o
left join
  sandbox_db_josha.dev_reporting.gl_transaction g
  on o.order_id_edw = g.order_id_edw
where o.tier != g.order_tier
```

# Post-merge activities
- [ ] update pipeline in Mozart to switch fact.customers to be dependent on bridge.orders instead of fact.orders
![image](https://github.com/user-attachments/assets/2c67a117-3e82-427e-9a20-7d3f11b738b0)
- [ ] send announcement to team data outlining the changes
  - NULL new_customer_order_flag for indirect
  - added new_customer_order_flag on fact.orders
  - aligned new_customer_order_flag on dev_reporting.gl_transaction and fact.orders
