### PR TITLE
Added revenue to the goodr.com usage KPIs table

### DIFF
--- a/mozartdata/transforms/dev_reporting/goodr_com_usage_kpis.sql
+++ b/mozartdata/transforms/dev_reporting/goodr_com_usage_kpis.sql
@@ -40,30 +40,29 @@ with
                             from
                                 goodr_reporting.performance_media as pm
                             where
-                                  pm.account_country ='USA'
+                                  pm.account_country = 'USA'
                               and date >= '2024-01-01'
                               and date <= current_date
                             group by
                                 date
                         )
-  -- removed until we know what we want to use for product_sales totals as a source of truth
-  -- , product_sales_totals as (
-  --                           select
-  --                               gl_tran.transaction_date          as date
-  --                             , round(sum(gl_tran.net_amount), 2) as total_product_sales
-  --                           from
-  --                               dev_reporting.gl_transaction as gl_tran
-  --                           where
-  --                                 gl_tran.posting_flag = true
-  --                             and gl_tran.channel = 'Goodr.com'
-  --                             and gl_tran.account_number in (
-  --                                                            4000, 4110, 4210
-  --                               )
-  --                             and gl_tran.transaction_date >= '2024-01-01'
-  --                             and gl_tran.transaction_date <= current_date
-  --                           group by
-  --                               gl_tran.transaction_date
-  --                       )
+  , revenue_daily_totals as (
+                            select
+                                gl_tran.transaction_date
+                              , sum(gl_tran.net_amount) as total_revenue
+                            from
+                                dev_reporting.gl_transaction as gl_tran
+                            where
+                                  gl_tran.posting_flag = true
+                              and gl_tran.channel = 'Goodr.com'
+                              and gl_tran.account_number like '4%'
+                              and gl_tran.transaction_date >= '2024-01-01'
+                              and gl_tran.transaction_date <= current_date
+                            group by
+                                gl_tran.transaction_date
+                            order by
+                                gl_tran.transaction_date asc
+                        )
     -- removed as it is not used in any KPIs at the moment, but may be in the future
     -- , new_customer_revenue_totals as (
     --                           select
@@ -102,7 +101,7 @@ with
   , yotpo_loyalty_account_totals as (
                             select
                                 created_at_date as event_date
-                              , count(*)                         as daily_total_created_accounts
+                              , count(*)        as daily_total_created_accounts
                             from
                                 staging.yotpo_accounts_kpi_aggregation
                             where
@@ -120,13 +119,13 @@ select
   , shopify.sessions_completed_checkout                    as shopify_sessions_completed_checkout
   , marketing.total_spend                                  as marketing_spend
   , marketing.total_impressions                            as marketing_impressions
-  -- , gl_tran.total_product_sales
-  -- left in for potential future use for new vs existing customer product_sales
-  -- , new_customer_sales.new_customer_product_sales
-  -- , round(
-  --       (gl_tran.total_revenue - new_customer_sales.new_customer_product_sales)
-  --       , 2
-  --   )                                                      as existing_customer_product_sales
+  , gl_tran.total_revenue                                  as gl_total_revenue
+    -- left in for potential future use for new vs existing customer product_sales
+    -- , new_customer_sales.new_customer_product_sales
+    -- , round(
+    --       (gl_tran.total_revenue - new_customer_sales.new_customer_product_sales)
+    --       , 2
+    --   )                                                      as existing_customer_product_sales
   , ifnull(yotpo_redemptions.redeeming_customers, 0)       as yotpo_redeeming_customers
   , ifnull(yotpo_accounts.daily_total_created_accounts, 0) as yotpo_accounts_created
 from
@@ -139,15 +138,15 @@ from
         marketing_totals                          as marketing
             on
             d.date = marketing.event_date
-    -- left join
-    --     product_sales_totals                            as gl_tran
-    --         on
-    --         d.date = gl_tran.date
-    -- removed as it is not used in KPIs at the moment, but may be used in the future for product_sales
-    -- left join
-    --     new_customer_revenue_totals               as new_customer_sales
-    --         on
-    --         d.date = new_customer_sales.date
+    left join
+        revenue_daily_totals                      as gl_tran
+            on
+            d.date = gl_tran.transaction_date
+            -- removed as it is not used in KPIs at the moment, but may be used in the future for product_sales
+            -- left join
+            --     new_customer_revenue_totals               as new_customer_sales
+            --         on
+            --         d.date = new_customer_sales.date
     left join
         staging.yotpo_redemptions_kpi_aggregation as yotpo_redemptions
             on

--- a/mozartdata/transforms/dev_reporting/goodr_com_usage_kpis.sql
+++ b/mozartdata/transforms/dev_reporting/goodr_com_usage_kpis.sql
@@ -67,8 +67,6 @@ with
                               and date_trunc('month', gl_tran.transaction_date) = period.period_start_date
                             group by
                                 gl_tran.transaction_date
-                            order by
-                                gl_tran.transaction_date asc
                         )
     -- removed as it is not used in any KPIs at the moment, but may be in the future
     -- , new_customer_revenue_totals as (

--- a/mozartdata/transforms/dev_reporting/goodr_com_usage_kpis.sql
+++ b/mozartdata/transforms/dev_reporting/goodr_com_usage_kpis.sql
@@ -150,11 +150,11 @@ from
         revenue_daily_totals                      as gl_tran
             on
             d.date = gl_tran.transaction_date
-            -- removed as it is not used in KPIs at the moment, but may be used in the future for product_sales
-            -- left join
-            --     new_customer_revenue_totals               as new_customer_sales
-            --         on
-            --         d.date = new_customer_sales.date
+    -- removed as it is not used in KPIs at the moment, but may be used in the future for product_sales
+    -- left join
+    --     new_customer_revenue_totals               as new_customer_sales
+    --         on
+    --         d.date = new_customer_sales.date
     left join
         staging.yotpo_redemptions_kpi_aggregation as yotpo_redemptions
             on

--- a/mozartdata/transforms/dev_reporting/goodr_com_usage_kpis.sql
+++ b/mozartdata/transforms/dev_reporting/goodr_com_usage_kpis.sql
@@ -22,6 +22,8 @@
             This is the total spend on marketing across the platforms tracked in goodr_reporting.performance_media.
         marketing_impressions:
             This is the total amount of impressions (basically people tha saw an ad) across marketing platforms.
+        gl_total_revenue:
+            This is the total revenue for each day. Specifically it is all 4000 accounts totaled.
         yotpo_redeeming_customers:
             This is the total number of customers that redeemed points in a day.
                 - This may include Canada, I will find out from Jared soon
@@ -52,12 +54,17 @@ with
                               , sum(gl_tran.net_amount) as total_revenue
                             from
                                 dev_reporting.gl_transaction as gl_tran
+                                left join
+                                    dim.accounting_period    as period
+                                        on gl_tran.posting_period = period.posting_period
                             where
                                   gl_tran.posting_flag = true
                               and gl_tran.channel = 'Goodr.com'
                               and gl_tran.account_number like '4%'
                               and gl_tran.transaction_date >= '2024-01-01'
                               and gl_tran.transaction_date <= current_date
+                              and period.is_posting_flag = true
+                              and date_trunc('month', gl_tran.transaction_date) = period.period_start_date
                             group by
                                 gl_tran.transaction_date
                             order by
@@ -109,6 +116,7 @@ with
                             group by
                                 created_at_date
                         )
+
 select
     d.date                                                 as event_date
   , shopify.sessions                                       as shopify_sessions


### PR DESCRIPTION
# Issue/Summary
Per our meeting with marketing team this morning, we need to calculate Average Revenue Per User (ARPU) using a source that aligns with them. This will allow us to use that KPI for monthly business reviews.

# Solution
After conferring with Gabby and Josha we agreed to use dev_reporting.gl_transaction as the primary data source (over fact.orders, as fact.orders more aligns with Shopify than Netsuite). This also means that this table will become the end of the pipeline as before it was dev_reporting.gl_transaction, which had no descendants. 

- [x] Bring in revenue from dev_reporting.gl_transaction
- [x] Confirm it is accurate with Gabby and Josha

# QC
Cloned production db to my sandbox on the morning of 2-26-2025

## dev_reporting.goodr_com_usage_kpis
### row count ✔️
```
select 
    'prod usage KPI tbl' as tbl
    , count(*) as row_count
from
  prod_goodr_dwh.dev_reporting.goodr_com_usage_kpis
group by all
union all
select 
    'sam snadbox usage KPI tbl' as rbl
    , count(*) as row_count
from
  sandbox_db_sam.dev_reporting.goodr_com_usage_kpis
group by all
```

![image](https://github.com/user-attachments/assets/6712bbc9-9b27-4561-8e85-74ed3b074a67)

No row count change

### unique dates ✔️

```
select 
    * 
from
    dev_reporting.goodr_com_usage_kpis
qualify
    row_number() over (
        partition by event_date order by event_date asc
    ) > 1
```

No results, test passed.

## Matching Netsuite
I show a limited check on Netsuite limited to January of 2025, as that is the only relevant month so far. However, more checks were done for June and September 2024 with Gabby and they matched. The issue was when we look at November 2024, and that is a larger issue. For now, this is what is relevant.

I show only the relevant column from NS, as I don't want to do a huge screenshot. Too lazy to make a custom report. It is Jan 2025 posting period in the income statement report.

![image](https://github.com/user-attachments/assets/c10a558d-8d37-4eb2-84a2-8003e0176fde)

![image](https://github.com/user-attachments/assets/c58b4e90-8df6-4bc7-b37c-400e7cee8a29)

```
select 
    date_trunc('month', final.event_date) as month
  , sum(final.gl_total_revenue)           as revenue
from
    dev_reporting.goodr_com_usage_kpis as final
where
    date_trunc('month', final.event_date) = '2025-01-01'
group by
    date_trunc('month', final.event_date)
```
    
 # Post-Merge Activities
- [ ] Update ancestors for goodr.com KPIs table to include dev_reporting.gl_transaction
- [ ] Make the KPIs table the end of the pipeline (as it now uses a table that was the end of the pipeline)
