### PR TITLE
Add address to GL

### DIFF
--- a/mozartdata/transforms/dev_reporting/gl_transaction.sql
+++ b/mozartdata/transforms/dev_reporting/gl_transaction.sql
@@ -43,8 +43,15 @@ SELECT DISTINCT
 , gt.cleared_date
 , gt.order_id_shopify
 , o.new_customer_order_flag
+. noa.state
+, noa.state_abbreviation
+, noa.country
+, noa.zip_code
 FROM
   fact.gl_transaction gt
   LEFT JOIN
     fact.orders o
   ON o.order_id_edw = gt.order_id_edw
+  LEFT JOIN
+    dim.netsuite_order_address noa
+  ON noa.order_address_id_edw = gt.shipping_address_id_edw

--- a/mozartdata/transforms/dev_reporting/gl_transaction.sql
+++ b/mozartdata/transforms/dev_reporting/gl_transaction.sql
@@ -43,6 +43,8 @@ SELECT DISTINCT
 , gt.cleared_date
 , gt.order_id_shopify
 , o.new_customer_order_flag
+, gt.shipping_address_id_edw
+, gt.shipping_address_id_ns
 , noa.state
 , noa.state_abbreviation
 , noa.country

--- a/mozartdata/transforms/dev_reporting/gl_transaction.sql
+++ b/mozartdata/transforms/dev_reporting/gl_transaction.sql
@@ -1,4 +1,4 @@
-SELECT
+SELECT DISTINCT
   gt.gl_transaction_id_edw
 , gt.order_id_edw
 , gt.order_id_ns

--- a/mozartdata/transforms/dev_reporting/gl_transaction.sql
+++ b/mozartdata/transforms/dev_reporting/gl_transaction.sql
@@ -55,5 +55,5 @@ FROM
     fact.orders o
   ON o.order_id_edw = gt.order_id_edw
   LEFT JOIN
-    dim.netsuite_order_address noa
-  ON noa.order_address_id_edw = gt.shipping_address_id_edw
+    dim.netsuite_shipping_address noa
+  ON noa.shipping_address_id_edw = gt.shipping_address_id_edw

--- a/mozartdata/transforms/dev_reporting/gl_transaction.sql
+++ b/mozartdata/transforms/dev_reporting/gl_transaction.sql
@@ -1,4 +1,4 @@
-SELECT DISTINCT
+SELECT
   gt.gl_transaction_id_edw
 , gt.order_id_edw
 , gt.order_id_ns
@@ -43,7 +43,7 @@ SELECT DISTINCT
 , gt.cleared_date
 , gt.order_id_shopify
 , o.new_customer_order_flag
-. noa.state
+, noa.state
 , noa.state_abbreviation
 , noa.country
 , noa.zip_code

--- a/mozartdata/transforms/dev_reporting/gl_transaction.sql
+++ b/mozartdata/transforms/dev_reporting/gl_transaction.sql
@@ -49,6 +49,7 @@ SELECT DISTINCT
 , noa.state_abbreviation
 , noa.country
 , noa.zip_code
+, noa.normalized_zip_code
 FROM
   fact.gl_transaction gt
   LEFT JOIN

--- a/mozartdata/transforms/dim/netsuite_order_address.sql
+++ b/mozartdata/transforms/dim/netsuite_order_address.sql
@@ -1,3 +1,4 @@
+create or replace table dim.netsuite_order_address copy grants as
 with base as (
   select
     a.nkey

--- a/mozartdata/transforms/dim/netsuite_order_address.sql
+++ b/mozartdata/transforms/dim/netsuite_order_address.sql
@@ -64,7 +64,7 @@ with base as (
   union all
   select
     a.nkey
-  , 'invoice' as record_type
+  , 'salesorder' as record_type
   , a.addr1
   , a.addr2
   , a.addr3
@@ -79,7 +79,7 @@ with base as (
   , a.override
   , a.dropdownstate
   from
-    netsuite.invoiceshippingaddress a
+    netsuite.salesordershippingaddress a
   where
     _fivetran_deleted = false
   union all

--- a/mozartdata/transforms/dim/netsuite_order_address.sql
+++ b/mozartdata/transforms/dim/netsuite_order_address.sql
@@ -1,6 +1,6 @@
 with base as (
   select
-    a.nkey as address_id_ns
+    a.nkey as order_address_id_ns
   , 'invoice' as record_type
   , a.addr1 as address_1
   , a.addr2 as address_2
@@ -21,7 +21,7 @@ with base as (
     _fivetran_deleted = false
   union all
   select
-    a.nkey as address_id_ns
+    a.nkey as order_address_id_ns
   , 'cashsale' as record_type
   , a.addr1 as address_1
   , a.addr2 as address_2
@@ -42,7 +42,7 @@ with base as (
     _fivetran_deleted = false
   union all
   select
-    a.nkey as address_id_ns
+    a.nkey as order_address_id_ns
   , 'cashrefund' as record_type
   , a.addr1 as address_1
   , a.addr2 as address_2
@@ -63,7 +63,7 @@ with base as (
     _fivetran_deleted = false
   union all
   select
-    a.nkey as address_id_ns
+    a.nkey as order_address_id_ns
   , 'invoice' as record_type
   , a.addr1 as address_1
   , a.addr2 as address_2
@@ -82,10 +82,31 @@ with base as (
     netsuite.invoiceshippingaddress a
   where
     _fivetran_deleted = false
+  union all
+  select
+    a.nkey as order_address_id_ns
+  , 'itemfulfillment' as record_type
+  , a.addr1 as address_1
+  , a.addr2 as address_2
+  , a.addr3 as address_3
+  , a.addressee as customer_name
+  , a.addrphone as phone_number
+  , a.addrtext as address_text
+  , a.attention as attention
+  , a.city
+  , a.state
+  , a.country
+  , a.zip
+  , a.override
+  , a.dropdownstate as state_drop_down
+  from
+    netsuite.itemfulfillmentshippingaddress a
+  where
+    _fivetran_deleted = false
 )
 select
-  coalesce(b.record_type,'_',b.address_id_ns) as order_address_id_edw
-  , b.address_id_ns as order_address_id_ns
+    concat(b.record_type,'_',b.order_address_id_ns) as order_address_id_edw
+  , b.order_address_id_ns
   , b.record_type
   , b.address_1
   , b.address_2
@@ -106,5 +127,5 @@ from
   base b
 left join
   netsuite.state s
-  on b.state = s.state
+  on b.state = s.fullname
   and b.country = s.country

--- a/mozartdata/transforms/dim/netsuite_order_address.sql
+++ b/mozartdata/transforms/dim/netsuite_order_address.sql
@@ -103,7 +103,29 @@ with base as (
     netsuite.itemfulfillmentshippingaddress a
   where
     _fivetran_deleted = false
+  union all
+  select
+    a.nkey
+  , 'purchaseorder' as record_type
+  , a.addr1
+  , a.addr2
+  , a.addr3
+  , a.addressee
+  , a.addrphone
+  , a.addrtext
+  , a.attention
+  , a.city
+  , a.state
+  , a.country
+  , a.zip
+  , a.override
+  , a.dropdownstate
+  from
+    netsuite.purchaseordershippingaddress a
+  where
+    _fivetran_deleted = false
 )
+
 select
     concat(b.record_type,'_',b.nkey) as order_address_id_edw
   , b.nkey as order_address_id_ns
@@ -120,6 +142,7 @@ select
   , coalesce(sf.shortname, b.state) as state_abbreviation
   , b.country
   , b.zip as zip_code
+  , case when b.country = 'US' then left(trim(b.zip),5) else b.zip end as normalized_zip_code
   , case when b.override = 'T' then true else false end as override_flag
   , b.dropdownstate as state_drop_down
 from

--- a/mozartdata/transforms/dim/netsuite_order_address.sql
+++ b/mozartdata/transforms/dim/netsuite_order_address.sql
@@ -116,8 +116,8 @@ select
   , b.addrtext as address_text
   , b.attention
   , b.city
-  , b.state
-  , s.shortname as state_abbreviation
+  , coalesce(sa.fullname, b.state) as state
+  , coalesce(sf.shortname, b.state) as state_abbreviation
   , b.country
   , b.zip as zip_code
   , case when b.override = 'T' then true else false end as override_flag
@@ -125,6 +125,10 @@ select
 from
   base b
 left join
-  netsuite.state s
-  on b.state = s.fullname
-  and b.country = s.country
+  netsuite.state sf
+  on b.state = sf.fullname
+  and b.country = sf.country
+left join
+  netsuite.state sa
+  on b.state = sa.shortname
+  and b.country = sa.country

--- a/mozartdata/transforms/dim/netsuite_order_address.sql
+++ b/mozartdata/transforms/dim/netsuite_order_address.sql
@@ -1,4 +1,3 @@
-create or replace table dim.netsuite_order_address copy grants as
 with base as (
   select
     a.nkey
@@ -120,7 +119,7 @@ select
   , b.state
   , s.shortname as state_abbreviation
   , b.country
-  , b.zip
+  , b.zip as zip_code
   , case when b.override = 'T' then true else false end as override_flag
   , b.dropdownstate as state_drop_down
 from

--- a/mozartdata/transforms/dim/netsuite_order_address.sql
+++ b/mozartdata/transforms/dim/netsuite_order_address.sql
@@ -1,120 +1,119 @@
 with base as (
   select
-    a.nkey as order_address_id_ns
+    a.nkey
   , 'invoice' as record_type
-  , a.addr1 as address_1
-  , a.addr2 as address_2
-  , a.addr3 as address_3
-  , a.addressee as customer_name
-  , a.addrphone as phone_number
-  , a.addrtext as address_text
-  , a.attention as attention
+  , a.addr1
+  , a.addr2
+  , a.addr3
+  , a.addressee
+  , a.addrphone
+  , a.addrtext
+  , a.attention
   , a.city
   , a.state
   , a.country
   , a.zip
   , a.override
-  , a.dropdownstate as state_drop_down
+  , a.dropdownstate
   from
     netsuite.invoiceshippingaddress a
   where
     _fivetran_deleted = false
   union all
   select
-    a.nkey as order_address_id_ns
+    a.nkey
   , 'cashsale' as record_type
-  , a.addr1 as address_1
-  , a.addr2 as address_2
-  , a.addr3 as address_3
-  , a.addressee as customer_name
-  , a.addrphone as phone_number
-  , a.addrtext as address_text
-  , a.attention as attention
+  , a.addr1
+  , a.addr2
+  , a.addr3
+  , a.addressee
+  , a.addrphone
+  , a.addrtext
+  , a.attention
   , a.city
   , a.state
   , a.country
   , a.zip
   , a.override
-  , a.dropdownstate as state_drop_down
+  , a.dropdownstate
   from
     netsuite.cashsaleshippingaddress a
   where
     _fivetran_deleted = false
   union all
   select
-    a.nkey as order_address_id_ns
+    a.nkey
   , 'cashrefund' as record_type
-  , a.addr1 as address_1
-  , a.addr2 as address_2
-  , a.addr3 as address_3
-  , a.addressee as customer_name
-  , a.addrphone as phone_number
-  , a.addrtext as address_text
-  , a.attention as attention
+  , a.addr1
+  , a.addr2
+  , a.addr3
+  , a.addressee
+  , a.addrphone
+  , a.addrtext
+  , a.attention
   , a.city
   , a.state
   , a.country
   , a.zip
   , a.override
-  , a.dropdownstate as state_drop_down
+  , a.dropdownstate
   from
     netsuite.cashrefundshippingaddress a
   where
     _fivetran_deleted = false
   union all
   select
-    a.nkey as order_address_id_ns
+    a.nkey
   , 'invoice' as record_type
-  , a.addr1 as address_1
-  , a.addr2 as address_2
-  , a.addr3 as address_3
-  , a.addressee as customer_name
-  , a.addrphone as phone_number
-  , a.addrtext as address_text
-  , a.attention as attention
+  , a.addr1
+  , a.addr2
+  , a.addr3
+  , a.addressee
+  , a.addrphone
+  , a.addrtext
+  , a.attention
   , a.city
   , a.state
   , a.country
   , a.zip
   , a.override
-  , a.dropdownstate as state_drop_down
+  , a.dropdownstate
   from
     netsuite.invoiceshippingaddress a
   where
     _fivetran_deleted = false
   union all
   select
-    a.nkey as order_address_id_ns
+    a.nkey
   , 'itemfulfillment' as record_type
-  , a.addr1 as address_1
-  , a.addr2 as address_2
-  , a.addr3 as address_3
-  , a.addressee as customer_name
-  , a.addrphone as phone_number
-  , a.addrtext as address_text
-  , a.attention as attention
+  , a.addr1
+  , a.addr2
+  , a.addr3
+  , a.addressee
+  , a.addrphone
+  , a.addrtext
+  , a.attention
   , a.city
   , a.state
   , a.country
   , a.zip
   , a.override
-  , a.dropdownstate as state_drop_down
+  , a.dropdownstate
   from
     netsuite.itemfulfillmentshippingaddress a
   where
     _fivetran_deleted = false
 )
 select
-    concat(b.record_type,'_',b.order_address_id_ns) as order_address_id_edw
-  , b.order_address_id_ns
-  , b.record_type
-  , b.address_1
-  , b.address_2
-  , b.address_3
-  , b.customer_name
-  , b.phone_number
-  , NULLIF(REGEXP_REPLACE(b.phone_number, '^1|\\+1\\s?|\\(|\\)|-|\\s', ''), '') as normalized_phone_number
-  , b.address_text
+    concat(b.record_type,'_',b.nkey) as order_address_id_edw
+  , b.nkey as order_address_id_ns
+  , b.addr1 as address_1
+  , b.addr2 as address_2
+  , b.addr3 as address_3
+  , b.addressee as customer_name
+  , b.addrphone as phone_number
+  , NULLIF(REGEXP_REPLACE(b.addrphone, '^1|\\+1\\s?|\\(|\\)|-|\\s', ''), '') as normalized_phone_number
+  , b.addrtext as address_text
   , b.attention
   , b.city
   , b.state
@@ -122,7 +121,7 @@ select
   , b.country
   , b.zip
   , case when b.override = 'T' then true else false end as override_flag
-  , b.state_drop_down
+  , b.dropdownstate as state_drop_down
 from
   base b
 left join

--- a/mozartdata/transforms/dim/netsuite_order_address.sql
+++ b/mozartdata/transforms/dim/netsuite_order_address.sql
@@ -1,0 +1,110 @@
+with base as (
+  select
+    a.nkey as address_id_ns
+  , 'invoice' as record_type
+  , a.addr1 as address_1
+  , a.addr2 as address_2
+  , a.addr3 as address_3
+  , a.addressee as customer_name
+  , a.addrphone as phone_number
+  , a.addrtext as address_text
+  , a.attention as attention
+  , a.city
+  , a.state
+  , a.country
+  , a.zip
+  , a.override
+  , a.dropdownstate as state_drop_down
+  from
+    netsuite.invoiceshippingaddress a
+  where
+    _fivetran_deleted = false
+  union all
+  select
+    a.nkey as address_id_ns
+  , 'cashsale' as record_type
+  , a.addr1 as address_1
+  , a.addr2 as address_2
+  , a.addr3 as address_3
+  , a.addressee as customer_name
+  , a.addrphone as phone_number
+  , a.addrtext as address_text
+  , a.attention as attention
+  , a.city
+  , a.state
+  , a.country
+  , a.zip
+  , a.override
+  , a.dropdownstate as state_drop_down
+  from
+    netsuite.cashsaleshippingaddress a
+  where
+    _fivetran_deleted = false
+  union all
+  select
+    a.nkey as address_id_ns
+  , 'cashrefund' as record_type
+  , a.addr1 as address_1
+  , a.addr2 as address_2
+  , a.addr3 as address_3
+  , a.addressee as customer_name
+  , a.addrphone as phone_number
+  , a.addrtext as address_text
+  , a.attention as attention
+  , a.city
+  , a.state
+  , a.country
+  , a.zip
+  , a.override
+  , a.dropdownstate as state_drop_down
+  from
+    netsuite.cashrefundshippingaddress a
+  where
+    _fivetran_deleted = false
+  union all
+  select
+    a.nkey as address_id_ns
+  , 'invoice' as record_type
+  , a.addr1 as address_1
+  , a.addr2 as address_2
+  , a.addr3 as address_3
+  , a.addressee as customer_name
+  , a.addrphone as phone_number
+  , a.addrtext as address_text
+  , a.attention as attention
+  , a.city
+  , a.state
+  , a.country
+  , a.zip
+  , a.override
+  , a.dropdownstate as state_drop_down
+  from
+    netsuite.invoiceshippingaddress a
+  where
+    _fivetran_deleted = false
+)
+select
+  coalesce(b.record_type,'_',b.address_id_ns) as order_address_id_edw
+  , b.address_id_ns as order_address_id_ns
+  , b.record_type
+  , b.address_1
+  , b.address_2
+  , b.address_3
+  , b.customer_name
+  , b.phone_number
+  , NULLIF(REGEXP_REPLACE(b.phone_number, '^1|\\+1\\s?|\\(|\\)|-|\\s', ''), '') as normalized_phone_number
+  , b.address_text
+  , b.attention
+  , b.city
+  , b.state
+  , s.shortname as state_abbreviation
+  , b.country
+  , b.zip
+  , case when b.override = 'T' then true else false end as override_flag
+  , b.state_drop_down
+from
+  base b
+left join
+  netsuite.state s
+  on b.state = s.state
+  and b.country = s.country

--- a/mozartdata/transforms/dim/netsuite_shipping_address.sql
+++ b/mozartdata/transforms/dim/netsuite_shipping_address.sql
@@ -127,8 +127,8 @@ with base as (
 )
 
 select
-    concat(b.record_type,'_',b.nkey) as order_address_id_edw
-  , b.nkey as order_address_id_ns
+    concat(b.record_type,'_',b.nkey) as shipping_address_id_edw
+  , b.nkey as shipping_address_id_ns
   , b.addr1 as address_1
   , b.addr2 as address_2
   , b.addr3 as address_3

--- a/mozartdata/transforms/dim/netsuite_shipping_address.sql
+++ b/mozartdata/transforms/dim/netsuite_shipping_address.sql
@@ -134,7 +134,7 @@ select
   , b.addr3 as address_3
   , b.addressee as customer_name
   , b.addrphone as phone_number
-  , NULLIF(REGEXP_REPLACE(b.addrphone, '^1|\\+1\\s?|\\(|\\)|-|\\s', ''), '') as normalized_phone_number
+  , NULLIF(REGEXP_REPLACE(REGEXP_REPLACE(b.addrphone, '^1|\\+1\\s?|\\(|\\)|-|\\s', ''),'[^0-9]',''), '') as normalized_phone_number
   , b.addrtext as address_text
   , b.attention
   , b.city

--- a/mozartdata/transforms/fact/gl_transaction.sql
+++ b/mozartdata/transforms/fact/gl_transaction.sql
@@ -17,7 +17,6 @@ pe = paymentevent
 createdate convert to America/Los_Angeles
 use createdate converted instead of trandate
 */
-create or replace table fact.gl_transaction copy grants as
   select
       concat(tal.transaction,'_',tal.transactionline) as gl_transaction_id_edw
     , pt.order_id_edw

--- a/mozartdata/transforms/fact/gl_transaction.sql
+++ b/mozartdata/transforms/fact/gl_transaction.sql
@@ -68,8 +68,6 @@ use createdate converted instead of trandate
     , tran.custbody_boomi_orderid as order_id_shopify
     , tran.shippingaddress as shipping_address_id_ns
     , concat(tran.recordtype,'_',tran.shippingaddress) as shipping_address_id_edw
-    , tran.billingaddress as billing_address_id_ns
-    , concat(tran.recordtype,'_',tran.billingaddress) as billing_address_id_edw
     from
       netsuite.transactionaccountingline tal
     inner join

--- a/mozartdata/transforms/fact/gl_transaction.sql
+++ b/mozartdata/transforms/fact/gl_transaction.sql
@@ -17,6 +17,7 @@ pe = paymentevent
 createdate convert to America/Los_Angeles
 use createdate converted instead of trandate
 */
+create or replace table fact.gl_transaction copy grants as
   select
       concat(tal.transaction,'_',tal.transactionline) as gl_transaction_id_edw
     , pt.order_id_edw
@@ -66,6 +67,10 @@ use createdate converted instead of trandate
     , case when tl.cleared = 'T' then true else false end as cleared_flag
     , date(tl.cleareddate) AS cleared_date
     , tran.custbody_boomi_orderid as order_id_shopify
+    , tran.shippingaddress as shipping_address_id_ns
+    , concat(tran.recordtype,'_',tran.shippingaddress) as shipping_address_id_edw
+    , tran.billingaddress as billing_address_id_ns
+    , concat(tran.recordtype,'_',tran.billingaddress) as billing_address_id_edw
     from
       netsuite.transactionaccountingline tal
     inner join
@@ -114,37 +119,4 @@ use createdate converted instead of trandate
     and (tal._fivetran_deleted = false or tal._fivetran_deleted is null)
     and (tl._fivetran_deleted = false or tl._fivetran_deleted is null)
     and (pe._fivetran_deleted = false or pe._fivetran_deleted is null)
-    group by
-     concat(tal.transaction,'_',tal.transactionline)
-    , pt.order_id_edw
-    , COALESCE(pt.order_id_ns,REPLACE(COALESCE(tran.custbody_goodr_shopify_order,tran.custbody_goodr_po_number),' ',''))
-    , tran.id
-    , tran.tranid
-    , tran.recordtype
-    , tal."ACCOUNT"
-    , tal.transactionline
-    , ga.account_number
-    , ga.budget_category
-    , channel.name
-    , tran.trandate
-    , pe.eventdate
-    , ap.posting_period
-    , case when tal.posting = 'T' then true else false end
-    , createdfrom
-    , tran.entity
-    , cnm.customer_id_edw
-    , cnm.tier
-    , tl.department
-    , tl.item
-    , p.product_id_edw
-    , d.name
-    , tran.memo
-    , tl.memo
-    , c.fullname
-    , tl.cleared
-    , tl.cleareddate
-    , tran.custbody_boomi_orderid
-    , e.altname   
-    , e.type
-    , eline.altname
-    , eline.type
+    group by all


### PR DESCRIPTION
# Issue/Summary
We want to include the state/country/zip to GL tables

We'll start by creating `dim.netsuite_order_address`
- This table is called netsuite_order_address because it comes exclusively from NS (no shopify, or return platforms). Also because it only includes addresses for order record types. It does not include company or entity addresses. (future enhancement?)
- This table will have cashsale, invoice, itemfulfillment, cashrefund, item fulfillment addresses unioned together
- to use this table, we can join on address_id_ns or order_address_id_edw
# Solution
- [x] create dim.netsuite_order_address
We need to include record_type in the edw ID for cases like this: 
different addresses based on record type source.
```
select
  *
from
  dim.netsuite_order_address
where order_address_id_ns in (8896581)
```
- [x] surface shippingaddress as address_id_ns
- [x] add address to GL tables
# QC
## dim.netsuite_order_address
### Unique Row Test ✔️ 
```
select
  order_address_id_edw
, count(*) c
from
  dim.netsuite_order_address
group by all
having c>1
```
No Rows!

## fact.gl_transaction
### Row count test ✔️ 
```
select
  'prod_goodr_dwh' as db
  , count(*)
from
  prod_goodr_dwh.fact.gl_transaction
union all
select
  'sandbox_db_josha' as db
  , count(*)
from
  sandbox_db_josha.fact.gl_transaction
```
![image](https://github.com/user-attachments/assets/cba78720-7e75-4198-b5e9-e9f5a084da32)

## dev_reporting.gl_transaction
### Row count test ✔️ 
```
select
  'prod_goodr_dwh' as db
  , count(*)
from
  prod_goodr_dwh.dev_reporting.gl_transaction
union all
select
  'sandbox_db_josha' as db
  , count(*)
from
  sandbox_db_josha.dev_reporting.gl_transaction
```
![image](https://github.com/user-attachments/assets/b10761aa-5feb-4243-8014-2750eb97c860)

