### PR TITLE
CSV Clusters/Customers

### DIFF
--- a/mozartdata/transforms/fact/customer_ns_map.sql
+++ b/mozartdata/transforms/fact/customer_ns_map.sql
@@ -1,8 +1,58 @@
 SELECT
-  cust.customer_id_edw,
-  nc.*,
-  ct.tier as tier_2024,
-  case when cl.customer_id_ns is not null and cl.cluster is null then 3 else cl.cluster end as cluster
+  cust.customer_id_edw
+, nc.customer_id_ns
+, nc.customer_name
+, nc.customer_number
+, nc.parent_id_ns
+, nc.parent_customer_number
+, nc.parent_name
+, nc.is_person_flag
+, nc.is_parent_flag
+, nc.has_children_flag
+, nc.email
+, nc.normalized_email
+, nc.phone
+, nc.normalized_phone_number
+, nc.first_name
+, nc.last_name
+, nc.first_order_date
+, nc.first_sale_date
+, nc.last_order_date
+, nc.last_sale_date
+, nc.entity_title
+, nc.category_id_ns
+, nc.category
+, nc.company_name
+, nc.custentity_boomi_externalid
+, nc.custentity_boomi_source
+, nc.created_date
+, nc.default_billing_address
+, nc.default_shipping_address
+, nc.primary_sport_id_ns
+, nc.primary_sport
+, nc.secondary_sport_id_ns
+, nc.secondary_sport
+, nc.tertiary_sport_id_ns
+, nc.tertiary_sport
+, nc.tier_id_ns
+, nc.tier_ns
+, nc.tier
+, nc.doors
+, nc.buyer_name
+, nc.buyer_email
+, nc.pop_id_ns
+, nc.pop
+, nc.logistics_id_ns
+, nc.logistics
+, nc.city_1
+, nc.city_2
+, nc.city_3
+, nc.state_1
+, nc.state_2
+, nc.state_3
+, nc.duplicate
+, ct.tier as tier_2024
+,  case when cl.customer_id_ns is not null and cl.cluster is null then 3 else cl.cluster end as cluster
 FROM
   dim.CUSTOMER cust
 CROSS JOIN LATERAL FLATTEN(INPUT => cust.CUSTOMER_ID_NS) AS ns_ids

--- a/mozartdata/transforms/fact/customer_ns_map.sql
+++ b/mozartdata/transforms/fact/customer_ns_map.sql
@@ -2,7 +2,7 @@ SELECT
   cust.customer_id_edw,
   nc.*,
   ct.tier as tier_2024,
-  cluster.cluster
+  case when cl.customer_id_ns is not null and cl.cluster is null then 3 else cl.cluster end as cluster
 FROM
   dim.CUSTOMER cust
 CROSS JOIN LATERAL FLATTEN(INPUT => cust.CUSTOMER_ID_NS) AS ns_ids
@@ -13,5 +13,5 @@ LEFT OUTER JOIN
     staging.customer_tier_snapshot_2024 ct
     on nc.customer_id_ns = ct.customer_id_ns
 LEFT OUTER JOIN
-    csvs.netsuite_b2b_customer_clusters cluster
-    on nc.customer_id_ns = cluster.customer_id_ns
+    csvs.netsuite_b2b_customer_clusters cl
+    on nc.customer_id_ns = cl.customer_id_ns

--- a/mozartdata/transforms/fact/customer_ns_map.sql
+++ b/mozartdata/transforms/fact/customer_ns_map.sql
@@ -1,7 +1,8 @@
 SELECT
   cust.customer_id_edw,
   nc.*,
-  ct.tier as tier_2024
+  ct.tier as tier_2024,
+  cluster.cluster
 FROM
   dim.CUSTOMER cust
 CROSS JOIN LATERAL FLATTEN(INPUT => cust.CUSTOMER_ID_NS) AS ns_ids
@@ -11,3 +12,6 @@ LEFT OUTER JOIN
 LEFT OUTER JOIN
     staging.customer_tier_snapshot_2024 ct
     on nc.customer_id_ns = ct.customer_id_ns
+LEFT OUTER JOIN
+    csvs.netsuite_b2b_customer_clusters cluster
+    on nc.customer_id_ns = cluster.customer_id_ns

--- a/mozartdata/transforms/staging/customer_tier_snapshot_2024.sql
+++ b/mozartdata/transforms/staging/customer_tier_snapshot_2024.sql
@@ -1,23 +1,15 @@
 /*
-WARNING! DO NOT SCHEDULE THIS TRANSFORM TO RUN! IT IS A ONE-TIME RUN ONLY!
-
 This is a 1 time snapshot of fact.customer_ns_map to capture the 2024 tiers and doors associated with NS customers.
 Snapshot was originally taken on 1/13/2025.
 
 However, we found issues with Patrick Temple and Public Lands. So new snapshot is being taken on 1/15/2025 after making those fixes.
 
 Manual adjustment to move Patrick Temple to Fleet Feet. This was done in PR #103, but we are making a manual adjustment here for snapshot purposes, so we don't have to run the pipeline again.
-*/
-/*
-Commenting out select statement to reduce risk of data erroneously being updated.
 
-select
-  * exclude tier,
-  case when lower(company_name) = 'patrick temple' then 'Fleet Feet' else tier end as tier,
-  current_date as snapshot_date
+Update: uploaded a copy of this table as a CSV. Repointing the transform to point at the csv, so we can resolve the false/positive pipeline issues.
+*/
+
+SELECT
+  *
 from
-  fact.customer_ns_map
-where
-  tier is not null or doors is not null
-
-*/
+  csvs.customer_tier_snapshot_2024


### PR DESCRIPTION
# Issue/Summary
This PR will handle 2 key issues.
1. Update staging.customer_tier_snapshot_2024 to point at a CSV instead of fact.customer_ns_map which will remove a false positive circular reference.
2. Associate clusters CSV with customer_ns_map
# Solution
- [x] update staging.customer_tier_snapshot_2024
- [x] update fact.customer_ns_map with clusters
# QC
## staging.customer_tier_snapshot_2024
### Row Count Test ✔️ 
```
SELECT
  'staging.customer_tier_snapshot_2024' tbl,
  count(*)
from
  staging.customer_tier_snapshot_2024
group by all
UNION all
SELECT
  'csvs.customer_tier_snapshot_2024' tbl,
  count(*)
from
  csvs.customer_tier_snapshot_2024
group by all
```
![image](https://github.com/user-attachments/assets/852d0fef-bbc8-4606-ac94-2f5dfa5f6f17)

## fact.customer_ns_map
Verified the 218 customers have clusters. and the remainder are set to 3. Total equals 4422 customers in the gsheet. ✔️ 
![image](https://github.com/user-attachments/assets/b90009ef-0422-464e-ba81-1cf55e4ff4cf)

# PR Checklist
- [x] Is this a new base table? Did you include the root CTE? -> no root table
root code:
```
Base table: CTE root_table is used to get root table reference for scheduling in mozart.
If no longer a base table, then remove CTE root_table.
*/

with
  root_table as (
    select
        *
    from
        mozart.pipeline_root_table
    )
```
