### PR TITLE
added lens characteristics

### DIFF
--- a/mozartdata/transforms/dim/product.sql
+++ b/mozartdata/transforms/dim/product.sql
@@ -176,8 +176,10 @@ SELECT DISTINCT
   , templecolor.name                                 AS color_temple
   , framefinish.name                                 AS finish_frame
   , templefinish.name                                AS finish_temple
+  , lenscolorbase.name                               AS color_lens_base
   , lenscolor.name                                   AS color_lens_finish
-  , i.custitem24                                     AS lens_type
+  , lenstech.name                                    AS lens_tech
+  , lenstype.name                                    AS lens_type
   , design.name                                      AS design_tier
   , artwork.name                                     AS frame_artwork
   , i.custitem7                                      AS d2c_launch_timestamp
@@ -199,6 +201,13 @@ SELECT DISTINCT
   , i.custitem_goodr_ip_height                       AS ip_height_in
   , i.custitem_goodr_hts_code_item                   AS hts_code
   , i.CUSTITEM1                                      AS country_of_origin
+  , IFF(i.custitem_goodrcabana_item = 'T', TRUE, FALSE) as cabana_item_flag
+  , IFF(i.custitem_goodrwill_item = 'T', TRUE, FALSE) as goodrwill_item_flag
+  , IFF(i.custitem_goodrglobal_item = 'T', TRUE, FALSE) as global_item_flag
+  , IFF(i.custitem_sellgoodr_item = 'T', TRUE, FALSE) as sellgoodr_item_flag
+  , IFF(i.custitem_goodrsunglasses_item = 'T', TRUE, FALSE) as goodr_com_item_flag
+  , IFF(i.custitemcustitem_goodrcad_item = 'T', TRUE, FALSE) as goodr_ca_item_flag
+  , IFF(i.custitemcustitem_sellgoodrcad_item = 'T', TRUE, FALSE) as sellgoodr_ca_item_flag
   , IFF(i.custitem_stord_item = 'T', TRUE, FALSE)    AS stord_item_flag
   , IFF(i.custitem14 = 'T', TRUE, FALSE)             AS distributor_portal_item_flag
   , IFF(i.custitem25 = 'T', TRUE, FALSE)             AS key_account_prebook_item_flag
@@ -230,8 +239,12 @@ FROM
         ON i.custitem33 = templefinish.id
     LEFT JOIN netsuite.customlist990                               lenscolor
         ON i.custitem22 = lenscolor.id
-    LEFT JOIN netsuite.customlist_psgss_product_color              lenscolorbase
+    LEFT JOIN netsuite.CUSTOMLIST1273                             lenscolorbase
         ON i.custitem28 = lenscolorbase.id
+    LEFT JOIN netsuite.customlist992                               lenstype
+        ON i.custitem24 = lenstype.id
+    LEFT JOIN netsuite.CUSTOMLIST989                               lenstech
+        ON i.custitem23 = lenstech.id
     LEFT JOIN netsuite.customlist_psgss_merc_class                 class
         ON i.custitem_psgss_merc_class = class.id
     LEFT JOIN netsuite.customlist_psgss_merc_dept                  dept

--- a/mozartdata/transforms/dim/product.sql
+++ b/mozartdata/transforms/dim/product.sql
@@ -177,7 +177,7 @@ SELECT DISTINCT
   , framefinish.name                                 AS finish_frame
   , templefinish.name                                AS finish_temple
   , lenscolorbase.name                               AS color_lens_base
-  , lenscolor.name                                   AS color_lens_finish
+  , lenscolorfinish.name                                   AS color_lens_finish
   , lenstech.name                                    AS lens_tech
   , lenstype.name                                    AS lens_type
   , design.name                                      AS design_tier

--- a/mozartdata/transforms/dim/product.sql
+++ b/mozartdata/transforms/dim/product.sql
@@ -237,7 +237,7 @@ FROM
         ON i.custitem21 = framefinish.id
     LEFT JOIN netsuite.customlist988                               templefinish
         ON i.custitem33 = templefinish.id
-    LEFT JOIN netsuite.customlist990                               lenscolor
+    LEFT JOIN netsuite.customlist990                               lenscolorfinish
         ON i.custitem22 = lenscolor.id
     LEFT JOIN netsuite.CUSTOMLIST1273                             lenscolorbase
         ON i.custitem28 = lenscolorbase.id


### PR DESCRIPTION
# Issue/Summary
Gabby and Brendan were requesting some new fields added to dim product.
![image](https://github.com/user-attachments/assets/01a27e9e-dc68-4c10-8fcb-26cc3192a568)
![image](https://github.com/user-attachments/assets/fd6f3e5d-91ff-4605-b976-9ea4b8c0480c)

# Solution
- [x] add [goodr] store related flags
- [x] add lens related items 

to review you can look at `sandbox_db_josha.dim.product` to see the new columns/updated table to QC
# QC
Row Check ✔️ 
![image](https://github.com/user-attachments/assets/4ad6271e-d828-4341-8e6b-6b3935c183a5)

Sample testing: ✔️ 
From gabby via [slack](https://bowtieanalytics-1.slack.com/archives/C04RWQWTB1D/p1742324488336119)
https://5631345.app.netsuite.com/app/common/item/item.nl?id=5388&whence=
sku = G00322-OG-GD6-RF
![image](https://github.com/user-attachments/assets/c27ee8e2-0a8d-4c62-a955-6327f950af46)

Testing a couple from Brendan's sheet
skus in ('G00493-OG-TL6-RF','G00257-OG-BK1-FE')
![image](https://github.com/user-attachments/assets/fa6ccd54-fa96-4c31-8d5b-adedba60bb75)

![image](https://github.com/user-attachments/assets/8db69b74-990a-4e76-bc38-aecac45db3b7)


# PR Checklist
- [x] Is this a new base table? Did you include the root CTE? Not a root table
root code:
```
Base table: CTE root_table is used to get root table reference for scheduling in mozart.
If no longer a base table, then remove CTE root_table.
*/

with
  root_table as (
    select
        *
    from
        mozart.pipeline_root_table
    )
```
# Post Merge Activity
- [x] update gsheets.old_to_new_sku_map to use lens type names not IDs