### PR TITLE
Aftership enhancement 3-26-2025

### DIFF
--- a/mozartdata/transforms/dev_reporting/aftership_rma_items.sql
+++ b/mozartdata/transforms/dev_reporting/aftership_rma_items.sql
@@ -7,8 +7,12 @@
         Links fact.aftership_rma_items to dim.product to provide info on parts like lens, frame and vendor.
         each row contains the item returned and any items it was exchanged for, if any.
     Schema:
-        aftership_id: The organization on Aftership
-            Composite primary Key with original_product_id_aftership
+
+        org_id_aftership: id of the aftership org as defined by the dwh team
+            Composite Primary Key with rma_id_aftership and original_product_id_aftership
+        org_name_aftership: name of the aftership org as defined in aftership itself
+        rma_id_aftership: The id of the rma on Aftership
+            Composite primary Key with org_id_aftership and original_product_id_aftership
         rma_number_aftership: the main identifier for an Aftership customer request.
         rma_created_date: date rma was created
         rma_email: email of the customer that submitted the rma
@@ -19,7 +23,7 @@
         rma_return_type: what type of return is the item - return or no return
         original_product_id_aftership: id of the item being replaced from the original order. Is used to link the item being
             replaced with the item that is replacing it in the case of an exchange.
-            Composite primary Key with aftership_id
+            Composite primary Key with org_id_aftership and rma_id_aftership
         rma_item_product_id_edw: product_id_edw (sku) of the item
         rma_item_product_id_shopify: product id in Shopify of the item
         rma_item_variant_id_shopify: variant id in Shopify of the item
@@ -69,7 +73,9 @@
         rma_exchange_item_vendor_name: vendor of the item that is replacing the returned item per dim.product
  */
 select
-    rma_items.rma_id_aftership
+    rma_items.org_id_aftership
+  , rma_items.org_name_aftership
+  , rma_items.rma_id_aftership
   , rma_items.rma_number_aftership
   , rma_items.created_date
   , rma_items.customer_email

--- a/mozartdata/transforms/dim/aftership_orgs.sql
+++ b/mozartdata/transforms/dim/aftership_orgs.sql
@@ -1,0 +1,17 @@
+/*
+    Table name:
+        dim.aftership_orgs
+    Created:
+        3-26-2025
+    Purpose:
+        Shows distinct aftership org ids and names as defined in the staging.aftership_rmas table.
+    Schema:
+        org_id_aftership: id of the organization, self defined in the staging.aftership_rmas table by data team
+            Primary Key
+        org_name_aftership: name of organization as it shows on the aftership front end, defined by creators of the org
+ */
+ select distinct
+    org_id_aftership
+    , org_name_aftership
+ from
+    staging.aftership_rmas

--- a/mozartdata/transforms/staging/aftership_rmas.sql
+++ b/mozartdata/transforms/staging/aftership_rmas.sql
@@ -9,9 +9,11 @@
         warranty data as of its creation due to that information not flowing through the API - it requires
         webhooks, which can be implemented in the future if desired.
     Schema:
-        aftership_org: The organization on Aftership
+        org_id_aftership: id of the organization (created in dwh since we don't get from Portable)
+            Composite primary key with rma_id_aftership
+        org_name_aftership: The organization on Aftership
         rma_id_aftership: unique id of rma on Aftership
-            Primary key
+            Composite primary key with org_id_aftership
         rma_number_aftership: the main identifier for an Aftership customer request within an Aftership organization
         original_order_id_edw: the order number of the original order that is associated with the RMA.
             Foreign key to fact.orders.order_id_edw and fact.aftership_rma_items.original_order_id_edw
@@ -71,7 +73,8 @@ with
     )
 
 select
-    'USA - returns + 3rd party'                                                      as aftership_org
+    1                                                                                as org_id_aftership
+  , 'USA - returns + 3rd party'                                                      as org_name_aftership
   , us_returns_3p_warranties.id                                                      as rma_id_aftership
   , us_returns_3p_warranties.rma_number                                              as rma_number_aftership
   , us_returns_3p_warranties._order:ORDER_NUMBER::varchar                            as original_order_id_edw
@@ -122,7 +125,8 @@ from
     aftership_returns_usa_and_3rd_party_warranties_portable.returns as us_returns_3p_warranties
 union all
 select
-    'Canada - returns + 3rd party'                                                    as aftership_org
+    2                                                                                 as org_id_aftership
+  , 'Canada - returns + 3rd party'                                                    as org_name_aftership
   , can_returns_3p_warranties.id                                                      as rma_id_aftership
   , can_returns_3p_warranties.rma_number                                              as rma_number_aftership
   , can_returns_3p_warranties._order:ORDER_NUMBER::varchar                            as original_order_id_edw
@@ -173,7 +177,8 @@ from
     aftership_returns_canada_and_3rd_party_warranties_portable.returns as can_returns_3p_warranties
 union all
 select
-    'USA - warranty'                                                       as aftership_org
+    3                                                                      as org_id_aftership
+  , 'USA - warranty'                                                       as org_name_aftership
   , usa_warranties.id                                                      as rma_id_aftership
   , usa_warranties.rma_number                                              as rma_number_aftership
   , usa_warranties._order:ORDER_NUMBER::varchar                            as original_order_id_edw
@@ -224,7 +229,8 @@ from
     aftership_usa_warranties_portable.returns as usa_warranties
 union all
 select
-    'Canada - warranty'                                                    as aftership_org
+    4                                                                      as org_id_aftership
+  , 'Canada - warranty'                                                    as org_name_aftership
   , can_warranties.id                                                      as rma_id_aftership
   , can_warranties.rma_number                                              as rma_number_aftership
   , can_warranties._order:ORDER_NUMBER::varchar                            as original_order_id_edw

--- a/mozartdata/transforms/staging/aftership_rmas_exchange_warranty_items.sql
+++ b/mozartdata/transforms/staging/aftership_rmas_exchange_warranty_items.sql
@@ -13,15 +13,17 @@
         related to items being sent to a customer (an exchange).
 
     Schema:
-        aftership_org: The organization on Aftership
+        org_id_aftership: id of the organization (created in dwh since we don't get from Portable)
+            Composite primary Key with rma_id_aftership and org_id_aftership
+        org_name_aftership: The organization on Aftership
         rma_id_aftership: unique id of rma on Aftership
-            Composite primary Key with original_item_aftership_id
+            Composite primary Key with original_item_aftership_id and org_id_aftership
         rma_number_aftership: the main identifier for an Aftership customer request within an Aftership organization
         original_order_id_edw: the order number of the original order that is associated with the RMA.
             Foreign key to fact.orders.order_id_edw and fact.aftership_rmas.original_order_id_edw
         original_order_id_shopify: id as it is shows in the address bar when viewing it on the shopify website
         original_item_aftership_id: unique aftership id of the originally ordered item that the exchange is replacing
-            Composite primary Key with rma_id_aftership
+            Composite primary Key with rma_id_aftership and org_id_aftership
         original_item_product_id_edw: product_id_edw (sku) of the item being replaced in the exchange
         original_item_product_id_shopify: product_id in shopify of the item being replaced in the exchange
         original_item_display_name: display name of the item being replaced in the exchange
@@ -42,7 +44,8 @@ with
     )
 
 select
-    'USA - returns + 3rd party'                                          as aftership_org
+    1                                                                    as org_id_aftership
+  , 'USA - returns + 3rd party'                                          as org_name_aftership
   , us_returns_3p_warranties.id                                          as rma_id_aftership
   , us_returns_3p_warranties.rma_number                                  as rma_number_aftership
   , us_returns_3p_warranties._order:ORDER_NUMBER::varchar                as original_order_id_edw
@@ -64,7 +67,8 @@ from
             )                                                       as exchange_items
 union all
 select
-    'Canada - returns + 3rd party'                                       as aftership_org
+    2                                                                    as org_id_aftership
+  , 'Canada - returns + 3rd party'                                       as org_name_aftership
   , can_returns_3p_warranties.id                                         as rma_id_aftership
   , can_returns_3p_warranties.rma_number                                 as rma_number_aftership
   , can_returns_3p_warranties._order:ORDER_NUMBER::varchar               as original_order_id_edw
@@ -86,7 +90,8 @@ from
             )                                                          as exchange_items
 union all
 select
-    'USA - warranty'                                                     as aftership_org
+    3                                                                    as org_id_aftership
+  , 'USA - warranty'                                                     as org_name_aftership
   , usa_warranties.id                                                    as rma_id_aftership
   , usa_warranties.rma_number                                            as rma_number_aftership
   , usa_warranties._order:ORDER_NUMBER::varchar                          as original_order_id_edw
@@ -108,7 +113,8 @@ from
             )                                 as exchange_items
 union all
 select
-    'Canada - warranty'                                                  as aftership_org
+    4                                                                    as org_id_aftership
+  , 'Canada - warranty'                                                  as org_name_aftership
   , can_warranties.id                                                    as rma_id_aftership
   , can_warranties.rma_number                                            as rma_number_aftership
   , can_warranties._order:ORDER_NUMBER::varchar                          as original_order_id_edw

--- a/mozartdata/transforms/staging/aftership_rmas_refund_return_items.sql
+++ b/mozartdata/transforms/staging/aftership_rmas_refund_return_items.sql
@@ -13,15 +13,17 @@
         related to items being refunded for or returned.
 
     Schema:
-        aftership_org: The organization on Aftership
+        org_id_aftership: id of the organization (created in dwh since we don't get from Portable)
+            Composite primary Key with rma_id_aftership and original_item_aftership_id
+        org_name_aftership: The organization on Aftership
         rma_id_aftership: unique id of rma on Aftership
-            Composite primary Key with original_item_aftership_id
+            Composite primary Key with original_item_aftership_id and org_id_aftership
         rma_number_aftership: the main identifier for an Aftership customer request within an Aftership organization
         original_order_id_edw:the order number of the original order that is associated with the RMA.
             Foreign key to fact.orders.order_id_edw and fact.aftership_rmas.original_order_id_edw
         original_order_id_shopify: id as it is shows in the address bar when viewing it on the shopify website
         return_item_aftership_id: item id in the return.
-            Composite primary Key with aftership_id
+            Composite primary Key with rma_id_aftership and org_id_aftership
         return_item_product_id_edw: product_id_edw (sku) of the item being returned/refunded
         return_item_product_id_shopify: product id in shopify of the item being returned/refunded
         return_item_variant_id_shopify: variant id in shopify of the item being returned/refunded
@@ -57,7 +59,8 @@ with
     )
 
 select
-    'USA - returns + 3rd party'                                              as aftership_org
+    1                                                                        as org_id_aftership
+  , 'USA - returns + 3rd party'                                              as org_name_aftership
   , us_returns_3p_warranties.id                                              as rma_id_aftership
   , us_returns_3p_warranties.rma_number                                      as rma_number_aftership
   , us_returns_3p_warranties._order:ORDER_NUMBER::varchar                    as original_order_id_edw
@@ -92,7 +95,8 @@ from
             )                                                       as return_items
 union all
 select
-    'Canada - returns + 3rd party'                                           as aftership_org
+    2                                                                        as org_id_aftership
+  , 'Canada - returns + 3rd party'                                           as org_name_aftership
   , can_returns_3p_warranties.id                                             as rma_id_aftership
   , can_returns_3p_warranties.rma_number                                     as rma_number_aftership
   , can_returns_3p_warranties._order:ORDER_NUMBER::varchar                   as original_order_id_edw
@@ -127,7 +131,8 @@ from
             )                                                          as return_items
 union all
 select
-    'USA - warranty'                                                         as aftership_org
+    3                                                                        as org_id_aftership
+  , 'USA - warranty'                                                         as org_name_aftership
   , usa_warranties.id                                                        as rma_id_aftership
   , usa_warranties.rma_number                                                as rma_number_aftership
   , usa_warranties._order:ORDER_NUMBER::varchar                              as original_order_id_edw
@@ -162,7 +167,8 @@ from
             )                                 as return_items
 union all
 select
-    'Canada - warranty'                                                      as aftership_org
+    4                                                                        as org_id_aftership
+  , 'Canada - warranty'                                                      as org_name_aftership
   , can_warranties.id                                                        as rma_id_aftership
   , can_warranties.rma_number                                                as rma_number_aftership
   , can_warranties._order:ORDER_NUMBER::varchar                              as original_order_id_edw


### PR DESCRIPTION
# Issue/Summary

Aftership told us the primary key needs to have org id because rma id is not unique across orgs

# Solution

- [X] create org id in staging tables
- [X] create dim.aftership_orgs
- [X] add dim table and info to fact and dev_reporting tables

# QC
limiting this to the top-level tables since this is a minor enhancement

##row check 
###fact.aftership_rmas ✔️
```
select 
    'sandbox_db_sam.fact.aftership_rmas' as table_name
    , count(*) as row_count
from 
    sandbox_db_sam.fact.aftership_rmas
union all
select 
    'prod_goodr_dwh.fact.aftership_rmas' as table_name
    , count(*) as row_count
from 
    prod_goodr_dwh.fact.aftership_rmas
```
![{B955EB14-B3F6-40E8-80B1-DB9467BEEAB3}](https://github.com/user-attachments/assets/f258ad9c-2687-42e0-88b4-6d182909f0fb)

###dev_reporting.aftership_rma_items ✔️
```
select 
    'sandbox_db_sam.dev_reporting.aftership_rma_items' as table_name
    , count(*) as row_count
from 
    sandbox_db_sam.dev_reporting.aftership_rma_items
union all
select 
    'prod_goodr_dwh.dev_reporting.aftership_rma_items' as table_name
    , count(*) as row_count
from 
    prod_goodr_dwh.dev_reporting.aftership_rma_items
```
![{5FD94BF6-A441-4ABF-8CC1-4C09DCF6C9BB}](https://github.com/user-attachments/assets/31cdcb81-11aa-44f9-9f15-dfca44863454)

##PK check
###fact.aftership_rmas ✔️
```
select
    *
from
    fact.aftership_rmas
qualify 
    count(*) over (partition by org_id_aftership, rma_id_aftership) > 1
```
![{5E0B8FA0-C800-4777-8158-D381412A1FFA}](https://github.com/user-attachments/assets/19575fef-3205-405c-be07-d47614cf2c0a)

###dev_reporting.aftership_rma_items ✔️
```
select
    *
from
    dev_reporting.aftership_rma_items
qualify 
    count(*) over ( 
        partition by 
            org_id_aftership
            , rma_id_aftership
            , original_product_id_aftership
    ) > 1
```
![{B77F2760-2134-4980-8FB3-51183EE0AF60}](https://github.com/user-attachments/assets/c66a13f3-a4b2-41de-926e-0047513ee302)

# PR Checklist
- [ ] Is this a new base table? Did you include the root CTE?
No, it is not base

root code:
```
Base table: CTE root_table is used to get root table reference for scheduling in mozart.
If no longer a base table, then remove CTE root_table.
*/

with
  root_table as (
    select
        *
    from
        mozart.pipeline_root_table
    )
```
