### PR TITLE
US Performance Media Export report

### DIFF
--- a/mozartdata/transforms/goodr_reporting/2025_us_season_performance_tracking.sql
+++ b/mozartdata/transforms/goodr_reporting/2025_us_season_performance_tracking.sql
@@ -1,0 +1,16 @@
+select
+    social_channel as partner
+  , TO_VARCHAR(DATE, 'Mon') as month
+  , funnel_stage
+  , sum(spend) as spend
+  , sum(impressions) as impressions
+  , sum(revenue) as purchase_value
+  , sum(clicks) as clicks
+  , sum(conversions) as purchases
+from
+  goodr_reporting.performance_media
+where
+  year = 2025
+and account_country = 'USA'
+and funnel_stage != 'OTHER'
+group by all

--- a/mozartdata/transforms/goodr_reporting/2025_us_season_performance_tracking.sql
+++ b/mozartdata/transforms/goodr_reporting/2025_us_season_performance_tracking.sql
@@ -13,4 +13,5 @@ where
   year = 2025
 and account_country = 'USA'
 and funnel_stage != 'OTHER'
+and social_channel != 'google ads'
 group by all


### PR DESCRIPTION
# Issue/Summary
Create a report for US 2025 data.

update: 
could not get reach or google ads data to tie out. circle back to those in phase 2.
# Solution
- [x] create a report
# QC
Snapchat ✔️ 
![image](https://github.com/user-attachments/assets/bd23b0f7-55a3-4e48-9a9e-7fd4eabd1e38)
![image](https://github.com/user-attachments/assets/702b9af8-7119-4c0a-ac8a-4a6f68a6ce73)

tiktok ✔️ 
![image](https://github.com/user-attachments/assets/9b8859e0-506e-4125-b226-9f558477ab67)

Meta ✔️ 
![image](https://github.com/user-attachments/assets/6d85b4db-4624-4666-ac3c-91d907177182)

# PR Checklist
- [x] Is this a new base table? Did you include the root CTE?
root code:
```
Base table: CTE root_table is used to get root table reference for scheduling in mozart.
If no longer a base table, then remove CTE root_table.
*/

with
  root_table as (
    select
        *
    from
        mozart.pipeline_root_table
    )
```

# Post Merge Activities
- [ ] schedule the gsheet export