### PR TITLE
Binventory detail

### DIFF
--- a/mozartdata/transforms/fact/bin_inventory_location.sql
+++ b/mozartdata/transforms/fact/bin_inventory_location.sql
@@ -1,0 +1,42 @@
+-- create or replace table fact.bin_inventory_location
+--     copy grants as
+--The idea with this table is bin sourced daily inventory counts, aggregated using business logic because we had trouble tracking Lagoon inventory using macro snapshot tables
+select
+    location_name
+  , sku
+  , display_name
+  , snapshot_date_fivetran
+  , sum(quantity_available) as netsuite_total_available
+  , sum(case
+            when
+                zone_name = 'General Zone' and bin_name not like 'Picked%' and bin_id != 1404
+                then quantity_available--Baseline condition, the super specific sub portion of "available" inventory that's actually not reserved
+            else 0
+        end-- This is the crux of all our work here, translating the logic of whats actually available to purchase in the Lagoon to code
+    )                       as edw_total_purchaseable
+  , sum(case
+            when zone_name = 'REI Zone'
+                then quantity_available
+            else 0
+        end)--Added this as when it seemed incredibly helpful for figuring out where inventory may be hiding
+                            as total_in_rei_zone
+  , sum(case
+            when bin_id = 1404
+                then quantity_available
+            else 0
+        end)--Another one that takes more than half our "Available" inventory
+                            as total_being_tagged
+  , sum(quantity_picked)    as total_quantity_picked
+from
+    fact.netsuite_bin_inventory
+where
+    location_id =
+    1 -- Filtering for only HQDC for the sake of this higher level table, since we have no bin/zone info for locations like Stord
+  and snapshot_date_fivetran > '2025-01-01'--We only turned this on in March 2025, all the 2023 data should be irrelevant?
+group by
+    location_name
+  , sku
+  , display_name
+  , snapshot_date_fivetran
+order by
+    snapshot_date_fivetran desc

--- a/mozartdata/transforms/fact/bin_inventory_location.sql
+++ b/mozartdata/transforms/fact/bin_inventory_location.sql
@@ -1,43 +1,43 @@
--- create or replace table fact.bin_inventory_location
---     copy grants as
+create or replace table fact.bin_inventory_location
+    copy grants as
 --The idea with this table is bin sourced daily inventory counts, aggregated using business logic because we had trouble tracking Lagoon inventory using macro snapshot tables
 select
-    location_name
+    final_location_name
   , sku
   , display_name
   , day
   , sum(case
             when
-                zone_name in ('General Zone', 'Carton Flow Zone') and bin_name not like 'Picked%' and bin_id != 1404
-                then quantity_available--Baseline condition, the super specific sub portion of "available" inventory that's actually not reserved
+                final_zone_name in ('General Zone', 'Carton Flow Zone') and final_binnumber not like 'Picked%' and final_bin_id != 1404
+                then final_carried_quantity_available--Baseline condition, the super specific sub portion of "available" inventory that's actually not reserved
             else 0
         end-- This is the crux of all our work here, translating the logic of whats actually available to purchase in the Lagoon to code
     )                       as edw_total_purchaseable
-  , sum(quantity_available) as netsuite_total_available
+  , sum(final_carried_quantity_available) as netsuite_total_available
 
   , sum(case
-            when zone_name = 'REI Zone'
-                then quantity_available
+            when final_zone_name = 'REI Zone'
+                then final_carried_quantity_available
             else 0
         end)--Added this as when it seemed incredibly helpful for figuring out where inventory may be hiding
                             as total_in_rei_zone
   , sum(case
-            when bin_id = 1404
-                then quantity_available
+            when final_bin_id = 1404
+                then final_carried_quantity_available
             else 0
         end)--Another one that takes more than half our "Available" inventory
                             as total_being_tagged
-  , sum(quantity_picked)    as total_quantity_picked
+  , sum(final_quantity_picked)    as total_quantity_picked
 from
     fact.netsuite_bin_inventory
 where
-    location_id =
-    1 -- Filtering for only HQDC for the sake of this higher level table, since we have no bin/zone info for locations like Stord
-  and snapshot_date_fivetran > '2025-01-01'--We only turned this on in March 2025, all the 2023 data should be irrelevant?
+    final_location_name =
+    'HQ DC' -- Filtering for only HQDC for the sake of this higher level table, since we have no bin/zone info for locations like Stord
+
 group by
-    location_name
+    final_location_name
   , sku
   , display_name
-  , snapshot_date_fivetran
+  , day
 order by
-    snapshot_date_fivetran desc
+    day desc

--- a/mozartdata/transforms/fact/bin_inventory_location.sql
+++ b/mozartdata/transforms/fact/bin_inventory_location.sql
@@ -1,5 +1,3 @@
--- create or replace table fact.bin_inventory_location
---     copy grants as
 --The idea with this table is bin sourced daily inventory counts, aggregated using business logic because we had trouble tracking Lagoon inventory using macro snapshot tables
 select
     final_location_name

--- a/mozartdata/transforms/fact/bin_inventory_location.sql
+++ b/mozartdata/transforms/fact/bin_inventory_location.sql
@@ -1,5 +1,5 @@
-create or replace table fact.bin_inventory_location
-    copy grants as
+-- create or replace table fact.bin_inventory_location
+--     copy grants as
 --The idea with this table is bin sourced daily inventory counts, aggregated using business logic because we had trouble tracking Lagoon inventory using macro snapshot tables
 select
     final_location_name

--- a/mozartdata/transforms/fact/bin_inventory_location.sql
+++ b/mozartdata/transforms/fact/bin_inventory_location.sql
@@ -5,7 +5,7 @@ select
     location_name
   , sku
   , display_name
-  , snapshot_date_fivetran
+  , day
   , sum(case
             when
                 zone_name in ('General Zone', 'Carton Flow Zone') and bin_name not like 'Picked%' and bin_id != 1404

--- a/mozartdata/transforms/fact/bin_inventory_location.sql
+++ b/mozartdata/transforms/fact/bin_inventory_location.sql
@@ -6,14 +6,15 @@ select
   , sku
   , display_name
   , snapshot_date_fivetran
-  , sum(quantity_available) as netsuite_total_available
   , sum(case
             when
-                zone_name = 'General Zone' and bin_name not like 'Picked%' and bin_id != 1404
+                zone_name in ('General Zone', 'Carton Flow Zone') and bin_name not like 'Picked%' and bin_id != 1404
                 then quantity_available--Baseline condition, the super specific sub portion of "available" inventory that's actually not reserved
             else 0
         end-- This is the crux of all our work here, translating the logic of whats actually available to purchase in the Lagoon to code
     )                       as edw_total_purchaseable
+  , sum(quantity_available) as netsuite_total_available
+
   , sum(case
             when zone_name = 'REI Zone'
                 then quantity_available

--- a/mozartdata/transforms/fact/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/fact/netsuite_bin_inventory.sql
@@ -1,7 +1,21 @@
 with
     staging as (
                    select
-                       binv.*
+                       binv.bin_id
+                       , binv.binnumber
+                       , binv.zone_id
+                       , binv.zone_name
+                       , binv.location
+                       , binv.location_name
+                       , binv.item
+                       , binv.snapshot_timestamp_fivetran
+                       , binv.snapshot_date_fivetran
+                       , binv.quantityavailable
+                       , binv.quantityonhand
+                       , binv.quantitypicked
+                       , binv.committedqtyperlocation
+                       , binv.committedqtyperseriallotnumber
+                       , binv.committedqtyperseriallotnumberlocation
                      , prod.sku
                      , prod.display_name
                    from

--- a/mozartdata/transforms/fact/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/fact/netsuite_bin_inventory.sql
@@ -1,20 +1,57 @@
 -- CREATE OR REPLACE TABLE fact.netsuite_bin_inventory
 --             COPY GRANTS  as
+with
+    distinct_skus as (
+                         select distinct
+                             item
+                           , sku
+                           , location
+                         from
+                             staging.netsuite_bin_inventory binv
+                             left outer join dim.product    prod
+                                 on prod.item_id_ns = binv.item
+                     )
+  , days as (
+                         select
+                             date
+                         from
+                             dim.date
+                     )
+  , sku_date_grid as (
+                         select
+                             s.sku
+                           , s.item
+                           , s.location
+                           , c.date
+                         from
+                             distinct_skus   s
+                             cross join days c
+                     )
 select
-    binv.bin_id
-  , binv.binnumber as bin_name
-  , binv.zone_name
-  , binv.location as location_id
-  , binv.location_name
-  , binv.item
-  , prod.sku
+    grid.date
+  , grid.location
+  , grid.sku
   , prod.display_name
+  , binv.bin_id
+  , binv.binnumber               as bin_name
+  , binv.zone_name
+  , binv.location                as location_id
+  , binv.location_name
   , binv.snapshot_date_fivetran
-  , binv.quantityavailable as quantity_available
-  , binv.quantityonhand as quantity_on_hand
-  , binv.quantitypicked as quantity_picked
-  , binv.committedqtyperlocation committed_qty_per_location
+  , binv.quantityavailable       as quantity_available
+  , binv.quantityonhand          as quantity_on_hand
+  , binv.quantitypicked          as quantity_picked
+  , binv.committedqtyperlocation as committed_qty_per_location
 from
-    staging.netsuite_bin_inventory binv
-    left outer join dim.product    prod
-        on prod.item_id_ns = binv.item
+    sku_date_grid                      grid
+    left outer join
+        staging.netsuite_bin_inventory binv
+            on binv.snapshot_date_fivetran = grid.date and binv.item = grid.item and binv.location = grid.location
+    left outer join dim.product        prod
+        on prod.item_id_ns = grid.item
+where
+      date = '2025-04-02'
+  and grid.item = 105
+
+
+--date >= '2025-04-01'--This is the start of all the relevant data unless we backfill

--- a/mozartdata/transforms/fact/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/fact/netsuite_bin_inventory.sql
@@ -25,7 +25,7 @@ with
                            on prod.item_id_ns = binv.item
                    where
                          binv.location = 1
-                     and snapshot_date_fivetran >= '2025-04-01'
+                     and binv.snapshot_date_fivetran >= '2025-04-01'
                )
   , distinct_skus as (
                    select distinct

--- a/mozartdata/transforms/fact/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/fact/netsuite_bin_inventory.sql
@@ -1,57 +1,172 @@
--- CREATE OR REPLACE TABLE fact.netsuite_bin_inventory
---             COPY GRANTS  as
+-- create or replace table fact.netsuite_bin_inventory
+--     copy grants as
 with
-    distinct_skus as (
-                         select distinct
-                             item
-                           , sku
-                           , location
-                         from
-                             staging.netsuite_bin_inventory binv
-                             left outer join dim.product    prod
-                                 on prod.item_id_ns = binv.item
-                     )
+    staging as (
+                   select
+                       binv.*
+                     , prod.sku
+                     , prod.display_name
+                   from
+
+                       staging.netsuite_bin_inventory binv
+                       left outer join dim.product    prod
+                           on prod.item_id_ns = binv.item
+                   where
+                         binv.location = 1
+                     and snapshot_date_fivetran >= '2025-04-01'
+               )
+  , distinct_skus as (
+                   select distinct
+                       item
+                     , sku
+                     , display_name
+                     , location
+                     , location_name
+                   from
+                       staging binv
+               )
   , days as (
-                         select
-                             date
-                         from
-                             dim.date
-                     )
+                   select
+                       date as day
+                   from
+                       dim.date
+                   where
+                       date between '2025-04-01' and current_date()
+               )
   , sku_date_grid as (
-                         select
-                             s.sku
-                           , s.item
-                           , s.location
-                           , c.date
-                         from
-                             distinct_skus   s
-                             cross join days c
-                     )
+                   select
+                       s.sku
+                     , s.display_name
+                     , s.item
+                     , s.location
+                     , s.location_name
+                     , c.day
+                   from
+                       distinct_skus   s
+                       cross join days c
+               )
+  , inventory_with_all_dates as (
+                                    -- Left join to get all records per item/date (could be multiple shelves or none)
+                   select
+                       grid.sku
+                     , grid.display_name
+                     , grid.day
+                     , binv.bin_id
+                     , binv.location_name
+                     , binv.binnumber
+                     , binv.zone_name
+                     , binv.quantityavailable       as quantity_available
+                     , binv.quantityonhand          as quantity_on_hand
+                     , binv.quantitypicked          as quantity_picked
+                     , binv.committedqtyperlocation as committed_qty_per_location
+                   from
+                       sku_date_grid     grid
+                       left join staging binv
+                           on grid.sku = binv.sku
+                           and grid.day = binv.snapshot_date_fivetran
+               )
+  , bin_summary as (
+                       -- Summarize per item + date
+                   select
+                       sku
+                     , display_name
+                     , day
+                       -- If there are no shelf entries, we'll get NULLs
+                     , count(bin_id) as shelf_count
+                   from
+                       inventory_with_all_dates
+                   group by
+                       all
+               )
+  , missing_day as
+        (
+                   select
+                       sku
+                     , display_name
+                     , day
+                     , shelf_count
+                   from
+                       bin_summary
+                   where
+                       shelf_count = 0
+               )
+  , last_day_with_inv as (
+                   select
+                       sku
+                     , day
+                     , shelf_count
+                   from
+                       bin_summary
+                   where
+                       shelf_count > 0
+               )
+  , last_day_data as
+        (
+                   select
+                       a.sku
+                     , a.day
+                     , b.bin_id
+                     , b.zone_name
+                     , b.binnumber
+                     , b.location_name
+                     , b.quantity_available
+                     , b.quantity_on_hand
+                     , b.quantity_picked
+                     , b.committed_qty_per_location
+                     , 1 as shelf_count
+                   from
+                       last_day_with_inv            a
+                       inner join
+                           inventory_with_all_dates b
+                               on a.sku = b.sku
+                               and a.day = b.day
+               )
+  , missing_day_fallback_dates as
+        (
+                   select
+                       m.day
+                     , m.sku
+                     , m.display_name
+                     , ld.day                        as fallback_day
+                     , ld.location_name              as fallback_location_name
+                     , ld.bin_id                     as fallback_bin_id
+                     , ld.binnumber                  as fallback_binnumber
+                     , ld.zone_name                  as fallback_zone_name
+                     , ld.quantity_available         as fallback_quantity_available
+                     , ld.quantity_on_hand           as fallback_quantity_on_hand
+                     , ld.quantity_picked            as fallback_quantity_picked
+                     , ld.committed_qty_per_location as fallback_committed_qty_per_location
+                   from
+                       missing_day       m
+                       left join
+                           last_day_data ld
+                               on ld.day < m.day
+                               and ld.sku = m.sku
+                   qualify
+                       rank() over (partition by m.day, m.sku order by ld.day desc) = 1
+               )
+
+
 select
-    grid.date
-  , grid.location
-  , grid.sku
-  , prod.display_name
-  , binv.bin_id
-  , binv.binnumber               as bin_name
-  , binv.zone_name
-  , binv.location                as location_id
-  , binv.location_name
-  , binv.snapshot_date_fivetran
-  , binv.quantityavailable       as quantity_available
-  , binv.quantityonhand          as quantity_on_hand
-  , binv.quantitypicked          as quantity_picked
-  , binv.committedqtyperlocation as committed_qty_per_location
+    iad.sku
+  , iad.display_name
+  , iad.bin_id
+  , iad.day
+    --     is_fallback,
+  , coalesce(location_name, fallback_location_name)                           as final_location_name
+  , coalesce(bin_id, fallback_bin_id)                                         as final_bin_id
+  , coalesce(binnumber, fallback_binnumber)                                   as final_binnumber
+  , coalesce(zone_name, fallback_zone_name)                                   as final_zone_name
+  , coalesce(quantity_available, fallback_quantity_available)                 as final_carried_quantity_available
+  , coalesce(quantity_on_hand, fallback_quantity_on_hand)                     as final_quantity_on_hand
+  , coalesce(quantity_picked, fallback_quantity_picked)                       as final_quantity_picked
+  , coalesce(committed_qty_per_location, fallback_committed_qty_per_location) as final_committed_qty_per_location
+
 from
-    sku_date_grid                      grid
-    left outer join
-        staging.netsuite_bin_inventory binv
-            on binv.snapshot_date_fivetran = grid.date and binv.item = grid.item and binv.location = grid.location
-    left outer join dim.product        prod
-        on prod.item_id_ns = grid.item
-where
-      date = '2025-04-02'
-  and grid.item = 105
-
-
---date >= '2025-04-01'--This is the start of all the relevant data unless we backfill
+    inventory_with_all_dates             iad
+    left join missing_day_fallback_dates m
+        on iad.sku = m.sku and iad.day = m.day
+order by
+    iad.sku
+  , iad.day
+  , final_bin_id;

--- a/mozartdata/transforms/fact/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/fact/netsuite_bin_inventory.sql
@@ -165,14 +165,14 @@ select
   , iad.bin_id
   , iad.day
     --     is_fallback,
-  , coalesce(location_name, fallback_location_name)                           as final_location_name
-  , coalesce(bin_id, fallback_bin_id)                                         as final_bin_id
-  , coalesce(binnumber, fallback_binnumber)                                   as final_binnumber
-  , coalesce(zone_name, fallback_zone_name)                                   as final_zone_name
-  , coalesce(quantity_available, fallback_quantity_available)                 as final_carried_quantity_available
-  , coalesce(quantity_on_hand, fallback_quantity_on_hand)                     as final_quantity_on_hand
-  , coalesce(quantity_picked, fallback_quantity_picked)                       as final_quantity_picked
-  , coalesce(committed_qty_per_location, fallback_committed_qty_per_location) as final_committed_qty_per_location
+  , coalesce(iad.location_name, m.fallback_location_name)                           as final_location_name
+  , coalesce(iad.bin_id, m.fallback_bin_id)                                         as final_bin_id
+  , coalesce(iad.binnumber, m.fallback_binnumber)                                   as final_binnumber
+  , coalesce(iad.zone_name, m.fallback_zone_name)                                   as final_zone_name
+  , coalesce(iad.quantity_available, m.fallback_quantity_available)                 as final_carried_quantity_available
+  , coalesce(iad.quantity_on_hand, m.fallback_quantity_on_hand)                     as final_quantity_on_hand
+  , coalesce(iad.quantity_picked, m.fallback_quantity_picked)                       as final_quantity_picked
+  , coalesce(iad.committed_qty_per_location, m.fallback_committed_qty_per_location) as final_committed_qty_per_location
 
 from
     inventory_with_all_dates             iad

--- a/mozartdata/transforms/fact/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/fact/netsuite_bin_inventory.sql
@@ -1,5 +1,3 @@
--- create or replace table fact.netsuite_bin_inventory
---     copy grants as
 with
     staging as (
                    select

--- a/mozartdata/transforms/fact/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/fact/netsuite_bin_inventory.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE TABLE fact.netsuite_bin_inventory
+            COPY GRANTS  as
+select
+    binv.bin_id
+  , binv.binnumber
+  , binv.zone_name
+  , binv.location as location_id
+  , binv.location_name
+  , binv.item
+  , prod.sku
+  , prod.display_name
+  , binv.snapshot_date_fivetran
+  , binv.quantityavailable
+  , binv.quantityonhand
+  , binv.quantitypicked
+  , binv.committedqtyperlocation
+from
+    staging.netsuite_bin_inventory binv
+    left outer join dim.product    prod
+        on prod.item_id_ns = binv.item

--- a/mozartdata/transforms/fact/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/fact/netsuite_bin_inventory.sql
@@ -1,8 +1,8 @@
-CREATE OR REPLACE TABLE fact.netsuite_bin_inventory
-            COPY GRANTS  as
+-- CREATE OR REPLACE TABLE fact.netsuite_bin_inventory
+--             COPY GRANTS  as
 select
     binv.bin_id
-  , binv.binnumber
+  , binv.binnumber as bin_name
   , binv.zone_name
   , binv.location as location_id
   , binv.location_name
@@ -10,10 +10,10 @@ select
   , prod.sku
   , prod.display_name
   , binv.snapshot_date_fivetran
-  , binv.quantityavailable
-  , binv.quantityonhand
-  , binv.quantitypicked
-  , binv.committedqtyperlocation
+  , binv.quantityavailable as quantity_available
+  , binv.quantityonhand as quantity_on_hand
+  , binv.quantitypicked as quantity_picked
+  , binv.committedqtyperlocation committed_qty_per_location
 from
     staging.netsuite_bin_inventory binv
     left outer join dim.product    prod

--- a/mozartdata/transforms/staging/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/staging/netsuite_bin_inventory.sql
@@ -1,5 +1,3 @@
--- create or replace table staging.netsuite_bin_inventory
---     copy grants as
 with
     root_table as (
                       select

--- a/mozartdata/transforms/staging/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/staging/netsuite_bin_inventory.sql
@@ -1,5 +1,5 @@
-create or replace table staging.netsuite_bin_inventory
-    copy grants as
+-- create or replace table staging.netsuite_bin_inventory
+--     copy grants as
 with
     root_table as (
                       select

--- a/mozartdata/transforms/staging/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/staging/netsuite_bin_inventory.sql
@@ -1,5 +1,5 @@
-CREATE OR REPLACE TABLE staging.netsuite_bin_inventory
-            COPY GRANTS  as
+create or replace table staging.netsuite_bin_inventory
+    copy grants as
 with
     root_table as (
                       select

--- a/mozartdata/transforms/staging/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/staging/netsuite_bin_inventory.sql
@@ -1,0 +1,37 @@
+with
+    root_table as (
+                      select
+                          *
+                      from
+                          mozart.pipeline_root_table
+    )
+select
+    binv.binnumber               as bin_id
+  , bins.binnumber
+  , bins.custrecord_rfs_pickzone as zone_id
+  , zone.name                    as zone_name
+  , binv.location
+  , loc.fullname                 as location_name
+  , binv.item
+  , binv._fivetran_synced        as snapshot_timestamp_fivetran
+  , date(binv._fivetran_synced)  as snapshot_date_fivetran
+  , binv.quantityavailable
+  , binv.quantityonhand
+  , binv.quantitypicked
+  , binv.committedqtyperlocation
+  , binv.committedqtyperseriallotnumber
+  , binv.committedqtyperseriallotnumberlocation
+from
+    netsuite.bininventorybalance                   binv
+    left outer join netsuite.bin                   bins
+        on bins.id = binv.binnumber
+    left outer join netsuite.location              loc
+        on loc.id = binv.location
+    left outer join netsuite.customrecord_rfs_zone zone
+        on zone.id = bins.custrecord_rfs_pickzone
+where
+      binv.location = 1
+  and binv.item = 50
+order by
+    snapshot_date_fivetran desc
+

--- a/mozartdata/transforms/staging/netsuite_bin_inventory.sql
+++ b/mozartdata/transforms/staging/netsuite_bin_inventory.sql
@@ -1,3 +1,5 @@
+CREATE OR REPLACE TABLE staging.netsuite_bin_inventory
+            COPY GRANTS  as
 with
     root_table as (
                       select
@@ -29,9 +31,6 @@ from
         on loc.id = binv.location
     left outer join netsuite.customrecord_rfs_zone zone
         on zone.id = bins.custrecord_rfs_pickzone
-where
-      binv.location = 1
-  and binv.item = 50
 order by
     snapshot_date_fivetran desc
 


### PR DESCRIPTION
# Issue/Summary
This is bringing in the netsuite bin inventory level information, so that we can have a better more accurate view of inventory movement in the DC, utilizing RF-Smart/WMS dimensions.
# Solution
A key note here is that this would be relatively simple, if it weren't for the backfill portion of the data. TLDR if there's no movement for a given sku, Fivetran will not snapshot ANY netsuite inventory data, and on any higher level reporting it makes it look like we had "null" inventory those days. To remedy this @Yoshu22 came up with a query that I (@KadenGoodr ) don't fully understand, but it works and passes the spot checking I was able to give it.
# QC
Used our top 5, and bottom 5 skus to mainly check if the backfill logic was not screwing up, because sadly theres no native NS report to QC this against, we're here because Netsuite doesn't actually snapshot inventory ever, its all transaction based. So we just kinda need to trust (like all the other inventory snapshot tables) that what fivetran says was in a given location's bin at a given time is correct.
Separately from the crazy backfill logic, the baseline tables are pretty simple, and the higher level one is aggregating all bins for a sku using a series of business logic decisions in simple case whens.
# PR Checklist
- [x] Is this a new base table? Did you include the root CTE?
root code:
```
Base table: CTE root_table is used to get root table reference for scheduling in mozart.
If no longer a base table, then remove CTE root_table.
*/

with
  root_table as (
    select
        *
    from
        mozart.pipeline_root_table
    )
```
