### PR TITLE
fixing location logic

### DIFF
--- a/mozartdata/transforms/fact/transfer_order_item_detail.sql
+++ b/mozartdata/transforms/fact/transfer_order_item_detail.sql
@@ -32,8 +32,8 @@ SELECT
 , t.quantity_received
 , t.quantity_backordered
 , t.quantity_allocated_demand
-, lship.name AS shipping_location
-, lrec.name AS receiving_location
+, case when record_type = 'itemreceipt' then ltran.name else lship.name end AS shipping_location
+, case when record_type = 'itemreceipt' then lship.name else ltran.name end AS receiving_location
 , t.requested_date
 , t.expected_receipt_date
 , t.expected_ship_date
@@ -47,3 +47,6 @@ SELECT
   LEFT JOIN
     dim.location lrec
     ON t.receiving_location = lrec.location_id_ns
+  LEFT JOIN
+    dim.location ltran
+    ON t.transfer_location = ltran.location_id_ns

--- a/mozartdata/transforms/staging/transfer_order_item_detail.sql
+++ b/mozartdata/transforms/staging/transfer_order_item_detail.sql
@@ -2,7 +2,6 @@
 Base table: CTE root_table is used to get root table reference for scheduling in mozart.
 If no longer a base table, then remove CTE root_table.
 */
-
 with
   root_table as (
     select
@@ -47,6 +46,7 @@ base  AS
   , DATE(tranlineship.expectedshipdate)                                     AS expected_ship_date
   , tranlineship.dayslate                                                   AS days_late
   , oas.name                                                                AS allocation_strategy
+  , tran.transferlocation                                                   AS transfer_location
   FROM
     netsuite.transaction tran
     LEFT OUTER JOIN netsuite.transactionline tranlineship


### PR DESCRIPTION
# Issue/Summary
The receiving location was NULL for IFs and IRs. 

Also for IF/IRs only the shipping location was populated.

# Solution
Pull in transfer location. Then update the logic to use this value for shipping or receiving location depending on the record type.
![image](https://github.com/user-attachments/assets/20d6f8e4-11ca-413b-8a0e-000d634528c9)

# QC
Checked values against this example:
https://5631345.app.netsuite.com/app/accounting/transactions/trnfrord.nl?id=31567055

row count test:
sandbox:
![image](https://github.com/user-attachments/assets/ebc2222d-d925-46ae-b19c-a08d0c7220e2)


# PR Checklist
- [x] Is this a new base table? Did you include the root CTE?
root code:
```
Base table: CTE root_table is used to get root table reference for scheduling in mozart.
If no longer a base table, then remove CTE root_table.
*/

with
  root_table as (
    select
        *
    from
        mozart.pipeline_root_table
    )
```
